### PR TITLE
feat(storage): add disk usage collection and API endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sentinel
 *.sqlite
 *.sqlite-wal
 *.sqlite-shm
+.ai/

--- a/API.md
+++ b/API.md
@@ -234,6 +234,67 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 
 ---
 
+### Disk Metrics
+
+#### Get Current Disk Usage
+
+Retrieve the latest stored filesystem usage, one entry per real mountpoint.
+
+**Endpoint:** `GET /api/disk/current`
+
+**Response:**
+```json
+[
+  {
+    "time": "1700000000000",
+    "mount": "/",
+    "total": 500000000000,
+    "used": 250000000000,
+    "available": 250000000000,
+    "usedPercent": 50.00
+  }
+]
+```
+
+**Fields:**
+- `time` (string): Unix timestamp in milliseconds
+- `mount` (string): Filesystem mountpoint
+- `total` (number): Total capacity in bytes
+- `used` (number): Used space in bytes
+- `available` (number): Available space in bytes
+- `usedPercent` (number): Disk usage percentage
+- `human_friendly_time` (string): ISO 8601 formatted timestamp (debug mode only)
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  http://localhost:8888/api/disk/current
+```
+
+---
+
+#### Get Disk Usage History
+
+Retrieve historical filesystem usage across mountpoints.
+
+**Endpoint:** `GET /api/disk/history`
+
+**Query Parameters:**
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `from` | string | No | `1970-01-01T00:00:00Z` | Start date in ISO 8601 format |
+| `to` | string | No | Current time | End date in ISO 8601 format |
+
+Response items use the same shape as `/api/disk/current`.
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:8888/api/disk/history?from=2024-01-15T00:00:00Z&to=2024-01-15T12:00:00Z"
+```
+
+---
+
 ## Docker Container Metrics
 
 ### Get Container CPU History
@@ -322,6 +383,62 @@ Retrieve memory usage history for a specific Docker container.
 ```bash
 curl -H "Authorization: Bearer YOUR_TOKEN" \
   "http://localhost:8888/api/container/postgres-db/memory/history?from=2024-01-15T00:00:00Z&to=2024-01-15T12:00:00Z"
+```
+
+---
+
+### Get Container Storage (Current)
+
+Retrieve the latest stored storage row for a container. Returns `null` when nothing has been recorded yet.
+
+**Endpoint:** `GET /api/container/:containerId/disk/current`
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Exact container display name recorded by Sentinel |
+
+**Response:**
+```json
+{
+  "time": "1700000000000",
+  "writableLayer": 12000000,
+  "volumesTotal": 340000000
+}
+```
+
+**Fields:**
+- `time` (string): Unix timestamp in milliseconds
+- `writableLayer` (number): Docker writable-layer size in bytes (`SizeRw`)
+- `volumesTotal` (number): Summed size in bytes of the container's volume/bind mounts (0 when `STORAGE_VOLUMES_ENABLED=false` or host paths aren't mounted)
+- `human_friendly_time` (string): ISO 8601 formatted timestamp (debug mode only)
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  http://localhost:8888/api/container/postgres-db/disk/current
+```
+
+---
+
+### Get Container Storage History
+
+Retrieve historical writable-layer and volume sizes for a container.
+
+**Endpoint:** `GET /api/container/:containerId/disk/history`
+
+**Query Parameters:**
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `from` | string | No | `1970-01-01T00:00:01Z` | Start date in ISO 8601 format |
+| `to` | string | No | Current time | End date in ISO 8601 format |
+
+Response items use the same shape as `/api/container/:containerId/disk/current`.
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:8888/api/container/postgres-db/disk/history?from=2024-01-15T00:00:00Z"
 ```
 
 ---

--- a/API.md
+++ b/API.md
@@ -427,6 +427,11 @@ Retrieve historical writable-layer and volume sizes for a container.
 
 **Endpoint:** `GET /api/container/:containerId/disk/history`
 
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerId` | string | Yes | Exact container display name recorded by Sentinel |
+
 **Query Parameters:**
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -299,7 +299,7 @@ Runs **latency → load → stress** with the shared target.
 
 ### 4.9 Storage collection micro-bench (`sentinel-bench storage`)
 
-The HTTP modes cover the storage **read** endpoints (`/api/disk/*`, `/api/container/{id}/disk/*`),
+The HTTP modes cover the host storage **read** endpoints (`/api/disk/current`, `/api/disk/history`),
 but the storage feature's real cost is **collector-side** and has no HTTP surface: the recursive
 volume `du`-walk, `sysinfo` disk enumeration, and store batch writes/downsample. This mode measures
 those directly by driving the **real** production functions (`collector::storage::dir_size` /

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -199,6 +199,8 @@ Default samples (HTTP 200 only for latency stats):
 | `/api/memory/current` | 80 |
 | `/api/cpu/history` | 40 |
 | `/api/memory/history` | 40 |
+| `/api/disk/current` | 80 |
+| `/api/disk/history` | 40 |
 
 Report: ok, fail, avg, p50, p95, p99, min, max (ms).
 
@@ -221,6 +223,7 @@ Fixed grid: each path × each concurrency for a timed window.
 | `/api/cpu/current` | 1, 10, 32 | 8 s each |
 | `/api/memory/current` | 1, 10, 32 | 8 s each |
 | `/api/cpu/history` | 1, 10, 32 | 8 s each |
+| `/api/disk/current` | 1, 10, 32 | 8 s each |
 
 Report: ok, fail, **RPS**, avg / p50 / p95 / p99 / max (ms), **error %**.
 
@@ -258,7 +261,7 @@ Stress answers: *“Under a nasty concurrent read mix, does the agent stay corre
 | `--max-p99-ms` | `0` (off) | Optional p99 ceiling |
 | `--health-every-secs` | `2` | Mid-run `/api/health` probes (0 = off) |
 
-**Traffic mix (weighted):** health 4, version 1, cpu/current 3, memory/current 3, cpu/history 2, memory/history 2.
+**Traffic mix (weighted):** health 4, version 1, cpu/current 3, memory/current 3, cpu/history 2, memory/history 2, disk/current 3, disk/history 2.
 
 **Pass criteria (default):**
 
@@ -289,10 +292,48 @@ Runs **latency → load → stress** with the shared target.
 | Item | Status |
 |------|--------|
 | Push payload success rate against a real Coolify mock | Not in default suite |
-| Container history endpoints | Optional; need a long-lived container ID |
+| Container history endpoints (cpu/memory/disk) | Optional; need a long-lived container ID |
 | Multi-host / noisy neighbor | Not required |
 | Absolute production capacity | Not claimed |
-| Writing load (mutating DB beyond collector) | Not in suite |
+| Writing load (mutating DB beyond collector) | Covered for storage by §4.9; not otherwise |
+
+### 4.9 Storage collection micro-bench (`sentinel-bench storage`)
+
+The HTTP modes cover the storage **read** endpoints (`/api/disk/*`, `/api/container/{id}/disk/*`),
+but the storage feature's real cost is **collector-side** and has no HTTP surface: the recursive
+volume `du`-walk, `sysinfo` disk enumeration, and store batch writes/downsample. This mode measures
+those directly by driving the **real** production functions (`collector::storage::dir_size` /
+`sample_disks`, `store::insert_disk_batch` / `insert_container_disk_batch` / `downsample`).
+
+```bash
+# Default: modest synthetic tree + 100k-row store phases
+./target/release/sentinel-bench storage
+
+# Stress: ~78k-file / ~305 MiB tree + 1M-row store/downsample burst
+./target/release/sentinel-bench storage --stress
+```
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--tree-dir` | `/tmp` | Where the synthetic tree is built (a unique subdir is created + removed) |
+| `--breadth` | `4` | Child dirs per level |
+| `--depth` | `4` | Tree nesting depth |
+| `--files-per-dir` | `8` | Files per directory |
+| `--file-bytes` | `4096` | Bytes per synthetic file |
+| `--rows` | `100000` | Total rows for the store-write / downsample phases |
+| `--keep` | off | Keep the synthetic tree after the run |
+| `--stress` | off | Larger worst-case preset (breadth 5, depth 5, 20 files/dir, 1M rows) |
+
+Reports four phases: **[A]** du-walk (files/s, bytes/s, min/avg/max ms), **[B]** `sample_disks`
+(ms, mount count), **[C]** disk + container batch insert throughput (rows/s), **[D]** downsample
+(rows collapsed, rows/s).
+
+**Interpreting it against the "system usage" concern:** the volume walk runs sequentially (one
+container at a time) on a blocking thread, once per `STORAGE_VOLUMES_REFRESH_RATE_SECONDS` (default
+900 s). Even a worst-case walk that takes a few hundred ms is a fraction of a percent duty cycle.
+**Caveat:** `--tree-dir` defaults to `/tmp`, which is often **tmpfs** (RAM) — that understates walk
+time on spinning/network disks where the walk is seek-bound. For a realistic figure, point
+`--tree-dir` at the same backing store as `/var/lib/docker/volumes`.
 
 ---
 
@@ -310,8 +351,9 @@ Runs **latency → load → stress** with the shared target.
 10. **Post-load memory** (§4.3).
 11. **`sentinel-bench stress`** (§4.6) — at least `mixed` 256×30s; add `ramp` / `burst` for release candidates.
 12. **Post-stress memory** (§4.3).
-13. `docker rm -f` bench containers; paste numbers into the results template.
-14. Note log noise (Docker stats errors, push failures — expected for blackhole push).
+13. **`sentinel-bench storage`** (§4.9) — default + `--stress`; runs on the host, no container needed.
+14. `docker rm -f` bench containers; paste numbers into the results template.
+15. Note log noise (Docker stats errors, push failures — expected for blackhole push).
 
 Quick path when you only care about “is this build sane under load?”:
 
@@ -440,7 +482,8 @@ Copy into `docs/benchmark-results/YYYY-MM-DD-<label>.md`:
 | File | Role |
 |------|------|
 | `BENCHMARK.md` (this file) | Spec — how to measure |
-| `crates/sentinel-bench/` | Rust harness (`sys` / `latency` / `load` / `stress` / `suite`) |
+| `crates/sentinel-bench/` | Rust harness (`sys` / `latency` / `load` / `stress` / `suite` / `storage`) |
+| `crates/sentinel-bench/src/storage_bench.rs` | Storage-feature micro-bench (§4.9) |
 | `docs/benchmark-results/` | Dated run reports (canonical history) |
 | `crates/collector/tests/startup_timing.rs` | Guards against reintroducing constructor sleep |
 | `Dockerfile` | Builds `-p sentinel` only (bench stays on the host) |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "store",
  "thiserror",
  "time",
  "tokio",
@@ -1514,10 +1515,12 @@ name = "sentinel-bench"
 version = "1.0.0"
 dependencies = [
  "clap",
+ "collector",
  "futures-util",
  "reqwest",
  "serde",
  "serde_json",
+ "store",
  "tokio",
 ]
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Sentinel is configured using environment variables:
 
 In development mode (`cargo run`/`cargo build` debug profile, or `SENTINEL_DEVELOPMENT=1`), `PUSH_ENDPOINT` defaults to `http://localhost:8000`.
 
-> **Storage collection & host paths.** Server disk stats reflect the filesystems Sentinel's own container can see. To size container **volumes/bind mounts**, the host paths must be mounted (read-only is fine) into Sentinel's container — typically `/var/lib/docker/volumes` plus any bind-mount roots — and `HOST_MOUNT_PREFIX` set to where they are mounted (e.g. `/host`). Paths that aren't accessible contribute `0` and log a warning rather than failing. Set `STORAGE_VOLUMES_ENABLED=false` to skip the walk entirely.
+> **Storage collection & host paths.** Server disk stats reflect the filesystems Sentinel's own container can see. To size container **volumes/bind mounts**, the host paths must be mounted (read-only is fine) into Sentinel's container — typically `/var/lib/docker/volumes` plus any bind-mount roots — and `HOST_MOUNT_PREFIX` set to where they are mounted (e.g. `/host`). Paths that aren't accessible contribute `0` and log a warning rather than failing. Note that a container bind-mounting a large host tree (e.g. `/`, `/var`, or a home directory) has that whole tree walked on every volume cycle, which can be slow; the walk is capped and records a partial size past the cap, but set `STORAGE_VOLUMES_ENABLED=false` to skip the walk entirely if that's a concern.
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -75,10 +75,17 @@ Sentinel is configured using environment variables:
 | `COLLECTOR_ENABLED` | `false` | Enable/disable metrics collection |
 | `COLLECTOR_REFRESH_RATE_SECONDS` | 5 | Metrics collection interval |
 | `COLLECTOR_RETENTION_PERIOD_DAYS` | 7 | How long to keep metrics in database |
+| `STORAGE_ENABLED` | `true` | Enable/disable storage (disk + container storage) collection |
+| `STORAGE_REFRESH_RATE_SECONDS` | 300 | Interval for the cheap per-mount filesystem stats |
+| `STORAGE_VOLUMES_ENABLED` | `true` | Enable/disable the per-container volume `du`-walk |
+| `STORAGE_VOLUMES_REFRESH_RATE_SECONDS` | 900 | Interval for the expensive volume walk (kept separate so it can't hammer host I/O) |
+| `HOST_MOUNT_PREFIX` | *(empty)* | Path prefix under which host paths are mounted into Sentinel's container, used to resolve volume/bind sources |
 | `DEBUG` | `false` | Enable verbose logging, `human_friendly_time` fields, and the `/api/stats` route |
 | `PORT` | `8888` | HTTP server port |
 
 In development mode (`cargo run`/`cargo build` debug profile, or `SENTINEL_DEVELOPMENT=1`), `PUSH_ENDPOINT` defaults to `http://localhost:8000`.
+
+> **Storage collection & host paths.** Server disk stats reflect the filesystems Sentinel's own container can see. To size container **volumes/bind mounts**, the host paths must be mounted (read-only is fine) into Sentinel's container — typically `/var/lib/docker/volumes` plus any bind-mount roots — and `HOST_MOUNT_PREFIX` set to where they are mounted (e.g. `/host`). Paths that aren't accessible contribute `0` and log a warning rather than failing. Set `STORAGE_VOLUMES_ENABLED=false` to skip the walk entirely.
 
 ### Example Configuration
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -68,6 +68,7 @@ pub fn router(state: Arc<AppState>) -> Router {
         )
         .merge(routes::cpu::routes())
         .merge(routes::memory::routes())
+        .merge(routes::disk::routes())
         .merge(routes::container::routes());
 
     if debug {

--- a/crates/api/src/routes/container.rs
+++ b/crates/api/src/routes/container.rs
@@ -8,7 +8,7 @@ use axum::{Json, Router};
 use crate::AppState;
 use crate::routes::cpu::{HistoryQuery, internal_error, resolve_range};
 use crate::time::format_millis;
-use crate::types::{CpuUsage, MemUsage};
+use crate::types::{ContainerDiskUsage, CpuUsage, MemUsage};
 
 /// Container history defaults `from` one second later than the host endpoints.
 /// This asymmetry exists in the Go implementation and is preserved.
@@ -21,6 +21,14 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route(
             "/api/container/{containerId}/memory/history",
             get(memory_history),
+        )
+        .route(
+            "/api/container/{containerId}/disk/current",
+            get(disk_current),
+        )
+        .route(
+            "/api/container/{containerId}/disk/history",
+            get(disk_history),
         )
 }
 
@@ -100,4 +108,69 @@ async fn memory_history(
         })
         .collect();
     Json(out).into_response()
+}
+
+/// Latest stored storage row for one container (`null` when none recorded yet).
+async fn disk_current(
+    Path(container_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    let permit = match state.history_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let store = state.store.clone();
+    let result =
+        tokio::task::spawn_blocking(move || store.container_disk_latest_one(&container_id)).await;
+    drop(permit);
+    let row = match result {
+        Ok(Ok(row)) => row,
+        Ok(Err(e)) => return internal_error(e),
+        Err(e) => return internal_error(e),
+    };
+
+    let debug = state.config.debug;
+    Json(row.map(|r| to_container_disk(r, debug))).into_response()
+}
+
+async fn disk_history(
+    Path(container_id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<HistoryQuery>,
+) -> Response {
+    let id = container_id;
+    let (from, to) = match resolve_range(&q, DEFAULT_FROM) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let permit = match state.history_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let store = state.store.clone();
+    let result =
+        tokio::task::spawn_blocking(move || store.container_disk_history(&id, from, to)).await;
+    drop(permit);
+    let rows = match result {
+        Ok(Ok(rows)) => rows,
+        Ok(Err(e)) => return internal_error(e),
+        Err(e) => return internal_error(e),
+    };
+
+    let debug = state.config.debug;
+    let out: Vec<ContainerDiskUsage> = rows
+        .into_iter()
+        .map(|r| to_container_disk(r, debug))
+        .collect();
+    Json(out).into_response()
+}
+
+fn to_container_disk(r: store::ContainerDiskRow, debug: bool) -> ContainerDiskUsage {
+    ContainerDiskUsage {
+        time: r.time.to_string(),
+        writable_layer: r.writable_layer,
+        volumes_total: r.volumes_total,
+        human_friendly_time: debug.then(|| format_millis(r.time)),
+    }
 }

--- a/crates/api/src/routes/disk.rs
+++ b/crates/api/src/routes/disk.rs
@@ -1,0 +1,73 @@
+use std::sync::Arc;
+
+use axum::extract::{Query, State};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+
+use crate::AppState;
+use crate::routes::cpu::{HistoryQuery, internal_error, resolve_range};
+use crate::time::format_millis;
+use crate::types::DiskUsage;
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/api/disk/current", get(current))
+        .route("/api/disk/history", get(history))
+}
+
+/// Latest stored snapshot: one row per mountpoint from the most recent cycle.
+async fn current(State(state): State<Arc<AppState>>) -> Response {
+    let permit = match state.history_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let store = state.store.clone();
+    let result = tokio::task::spawn_blocking(move || store.disk_latest()).await;
+    drop(permit);
+    let rows = match result {
+        Ok(Ok(rows)) => rows,
+        Ok(Err(e)) => return internal_error(e),
+        Err(e) => return internal_error(e),
+    };
+
+    let debug = state.config.debug;
+    let out: Vec<DiskUsage> = rows.into_iter().map(|r| to_disk_usage(r, debug)).collect();
+    Json(out).into_response()
+}
+
+async fn history(State(state): State<Arc<AppState>>, Query(q): Query<HistoryQuery>) -> Response {
+    let (from, to) = match resolve_range(&q, "1970-01-01T00:00:00Z") {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+
+    let permit = match state.history_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let store = state.store.clone();
+    let result = tokio::task::spawn_blocking(move || store.disk_history(from, to)).await;
+    drop(permit);
+    let rows = match result {
+        Ok(Ok(rows)) => rows,
+        Ok(Err(e)) => return internal_error(e),
+        Err(e) => return internal_error(e),
+    };
+
+    let debug = state.config.debug;
+    let out: Vec<DiskUsage> = rows.into_iter().map(|r| to_disk_usage(r, debug)).collect();
+    Json(out).into_response()
+}
+
+fn to_disk_usage(r: store::DiskRow, debug: bool) -> DiskUsage {
+    DiskUsage {
+        time: r.time.to_string(),
+        mount: r.mount,
+        total: r.total,
+        used: r.used,
+        available: r.available,
+        used_percent: r.used_percent,
+        human_friendly_time: debug.then(|| format_millis(r.time)),
+    }
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -1,4 +1,5 @@
 pub mod container;
 pub mod cpu;
+pub mod disk;
 pub mod memory;
 pub mod stats;

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -24,6 +24,34 @@ pub struct MemUsage {
     pub human_friendly_time: Option<String>,
 }
 
+/// Server filesystem usage for one mountpoint. These endpoints are new (not
+/// part of the frozen Go wire format), so `time` is a stringified millis for
+/// consistency with the other series while byte fields stay numeric.
+#[derive(Debug, Clone, Serialize)]
+pub struct DiskUsage {
+    pub time: String,
+    pub mount: String,
+    pub total: u64,
+    pub used: u64,
+    pub available: u64,
+    #[serde(rename = "usedPercent")]
+    pub used_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub human_friendly_time: Option<String>,
+}
+
+/// Per-container storage: Docker writable-layer size plus summed volume sizes.
+#[derive(Debug, Clone, Serialize)]
+pub struct ContainerDiskUsage {
+    pub time: String,
+    #[serde(rename = "writableLayer")]
+    pub writable_layer: u64,
+    #[serde(rename = "volumesTotal")]
+    pub volumes_total: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub human_friendly_time: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ErrorBody {
     pub error: String,

--- a/crates/api/tests/core.rs
+++ b/crates/api/tests/core.rs
@@ -97,6 +97,11 @@ fn test_state() -> std::sync::Arc<api::AppState> {
         collector_enabled: false,
         collector_retention_period_days: 7,
         bind_addr: std::net::SocketAddr::from(([127, 0, 0, 1], 0)),
+        storage_enabled: false,
+        storage_refresh_rate_seconds: 300,
+        storage_volumes_enabled: false,
+        storage_volumes_refresh_rate_seconds: 900,
+        host_mount_prefix: String::new(),
     };
     std::sync::Arc::new(api::AppState {
         auth_header: format!("Bearer {}", config.token),

--- a/crates/collector/src/lib.rs
+++ b/crates/collector/src/lib.rs
@@ -1,8 +1,10 @@
 #![forbid(unsafe_code)]
 
 pub mod host;
+pub mod storage;
 
 pub use host::HostSampler;
+pub use storage::StorageCollector;
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/collector/src/storage.rs
+++ b/crates/collector/src/storage.rs
@@ -143,13 +143,33 @@ fn resolve_host_path(prefix: &str, source: &str) -> PathBuf {
     }
 }
 
+/// Hard cap on directory entries visited in a single [`dir_size`] walk. A
+/// pathological bind mount (a container mounting `/`, `/var`, or a home dir for
+/// tooling) can otherwise enumerate millions of inodes on every storage cycle
+/// and stall the storage collector loop. Set well above any realistic single
+/// volume; when hit, [`dir_size`] logs a warning and records the partial sum.
+const MAX_WALK_ENTRIES: u64 = 2_000_000;
+
 /// Recursively sums on-disk block usage (like `du`) under `path`. Symlinks are
 /// never followed and any I/O error degrades to 0 with a warning — the walk
 /// must never crash a collection cycle.
 ///
+/// The walk is unbounded by depth and does not stop at filesystem boundaries,
+/// so a mount source that points at an arbitrarily large host tree (any bind
+/// mount, not just a Docker volume) is walked in full. To keep one pathological
+/// mount from stalling the collector, the walk is capped at [`MAX_WALK_ENTRIES`]
+/// entries; past that it logs a warning and returns the partial sum. Operators
+/// who don't want bind mounts walked can set `STORAGE_VOLUMES_ENABLED=false`.
+///
 /// `pub` so the host-only `sentinel-bench storage` harness can measure the real
 /// walk (see BENCHMARK.md §4.9); not part of any runtime API surface.
 pub fn dir_size(path: &Path) -> u64 {
+    dir_size_bounded(path, MAX_WALK_ENTRIES)
+}
+
+/// [`dir_size`] with an explicit entry budget, so the cap behaviour is testable
+/// without materializing millions of files.
+fn dir_size_bounded(path: &Path, max_entries: u64) -> u64 {
     let meta = match std::fs::symlink_metadata(path) {
         Ok(m) => m,
         Err(e) => {
@@ -169,6 +189,7 @@ pub fn dir_size(path: &Path) -> u64 {
     }
 
     let mut total = meta.blocks() * 512;
+    let mut entries_seen: u64 = 0;
     let mut stack = vec![path.to_path_buf()];
     while let Some(dir) = stack.pop() {
         let entries = match std::fs::read_dir(&dir) {
@@ -191,6 +212,16 @@ pub fn dir_size(path: &Path) -> u64 {
                 stack.push(entry.path());
             } else if ft.is_file() {
                 total += md.blocks() * 512;
+            }
+            entries_seen += 1;
+            if entries_seen >= max_entries {
+                tracing::warn!(
+                    path = %path.display(),
+                    entries = entries_seen,
+                    "storage: mount source walk exceeded entry budget, recording partial size \
+                     (a large bind mount? disable with STORAGE_VOLUMES_ENABLED=false)"
+                );
+                return total;
             }
         }
     }
@@ -305,6 +336,25 @@ mod tests {
         std::fs::write(dir.join("sub/b.bin"), vec![0u8; 4096]).unwrap();
         // At least the two files' worth of blocks (12 KiB) must be counted.
         assert!(dir_size(&dir) >= 12 * 1024);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn dir_size_bounded_stops_at_entry_cap() {
+        let dir =
+            std::env::temp_dir().join(format!("sentinel-storage-cap-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A flat directory of ten one-block files. Each contributes >0 blocks
+        // regardless of read_dir ordering, so a walk that stops after 3 entries
+        // is strictly smaller than the full walk — order-independent proof the
+        // cap short-circuits.
+        for i in 0..10 {
+            std::fs::write(dir.join(format!("f{i}.bin")), vec![0u8; 4096]).unwrap();
+        }
+        let full = dir_size_bounded(&dir, u64::MAX);
+        let capped = dir_size_bounded(&dir, 3);
+        assert!(capped < full, "capped={capped} full={full}");
         std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/crates/collector/src/storage.rs
+++ b/crates/collector/src/storage.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -103,13 +103,26 @@ impl StorageCollector {
         let prefix = self.config.host_mount_prefix.clone();
 
         match tokio::task::spawn_blocking(move || {
+            // Cache measured sizes for the whole collection cycle: a host source
+            // shared across containers (or mounted at several targets within one
+            // container) is `du`-walked only once.
+            let mut measured: HashMap<PathBuf, u64> = HashMap::new();
             let samples: Vec<ContainerDiskSample> = containers
                 .into_iter()
                 .map(|c| {
                     let volumes_total = if volumes_enabled {
                         c.mount_sources
                             .iter()
-                            .map(|src| dir_size(&resolve_host_path(&prefix, src)))
+                            .map(|src| resolve_host_path(&prefix, src))
+                            // Dedupe per container so one source mounted at
+                            // multiple targets is counted once, not summed twice.
+                            .collect::<HashSet<_>>()
+                            .into_iter()
+                            .map(|path| {
+                                *measured
+                                    .entry(path.clone())
+                                    .or_insert_with(|| dir_size(&path))
+                            })
                             .sum()
                     } else {
                         0

--- a/crates/collector/src/storage.rs
+++ b/crates/collector/src/storage.rs
@@ -1,0 +1,310 @@
+use std::collections::HashSet;
+use std::os::unix::fs::MetadataExt;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use config::Config;
+use docker::DockerClient;
+use store::{ContainerDiskSample, DiskSample, Store};
+use sysinfo::Disks;
+use tokio::sync::watch;
+use tokio::time::{Instant, MissedTickBehavior, interval_at};
+
+use crate::now_millis;
+
+/// Collects storage metrics on two independent cadences: cheap per-mount
+/// filesystem stats on `storage_refresh_rate_seconds`, and the more expensive
+/// per-container writable-layer + volume `du`-walk on
+/// `storage_volumes_refresh_rate_seconds`. Splitting the tickers keeps the
+/// heavy walk from being forced onto the fast disk-stat interval.
+pub struct StorageCollector {
+    config: Arc<Config>,
+    store: Store,
+    docker: DockerClient,
+}
+
+impl StorageCollector {
+    pub fn new(config: Arc<Config>, store: Store, docker: DockerClient) -> Self {
+        Self {
+            config,
+            store,
+            docker,
+        }
+    }
+
+    pub async fn run(self, mut shutdown: watch::Receiver<bool>) {
+        tracing::info!(
+            disk_refresh_seconds = self.config.storage_refresh_rate_seconds,
+            volumes_refresh_seconds = self.config.storage_volumes_refresh_rate_seconds,
+            volumes_enabled = self.config.storage_volumes_enabled,
+            "starting storage collector"
+        );
+
+        // interval_at defers the first tick by a full period, matching the
+        // Collector/Pusher startup timing (no immediate burst at boot).
+        let disk_period = Duration::from_secs(self.config.storage_refresh_rate_seconds);
+        let mut disk_ticker = interval_at(Instant::now() + disk_period, disk_period);
+        disk_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        let vol_period = Duration::from_secs(self.config.storage_volumes_refresh_rate_seconds);
+        let mut vol_ticker = interval_at(Instant::now() + vol_period, vol_period);
+        vol_ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    tracing::info!("stopping storage collector");
+                    return;
+                }
+                _ = disk_ticker.tick() => {
+                    self.collect_disk(now_millis()).await;
+                }
+                _ = vol_ticker.tick() => {
+                    self.collect_container_storage(now_millis()).await;
+                }
+            }
+        }
+    }
+
+    /// Enumerate real filesystems via sysinfo and record one row per mount.
+    /// A failed cycle logs and continues; it never propagates out of `run`.
+    async fn collect_disk(&self, time: i64) {
+        let store = self.store.clone();
+        match tokio::task::spawn_blocking(move || {
+            let samples = sample_disks();
+            store.insert_disk_batch(time, &samples)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(error = %e, "failed to record disk usage"),
+            Err(e) => tracing::warn!(error = %e, "disk usage insert task panicked"),
+        }
+    }
+
+    /// One `size: true` container list gives every container's writable-layer
+    /// size and mount sources; when volume walking is enabled, each mount's
+    /// host path is `du`-walked (sequentially, to bound I/O) and summed.
+    async fn collect_container_storage(&self, time: i64) {
+        let containers = match self.docker.list_container_sizes().await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to list container sizes");
+                return;
+            }
+        };
+        if containers.is_empty() {
+            return;
+        }
+
+        let store = self.store.clone();
+        let volumes_enabled = self.config.storage_volumes_enabled;
+        let prefix = self.config.host_mount_prefix.clone();
+
+        match tokio::task::spawn_blocking(move || {
+            let samples: Vec<ContainerDiskSample> = containers
+                .into_iter()
+                .map(|c| {
+                    let volumes_total = if volumes_enabled {
+                        c.mount_sources
+                            .iter()
+                            .map(|src| dir_size(&resolve_host_path(&prefix, src)))
+                            .sum()
+                    } else {
+                        0
+                    };
+                    ContainerDiskSample {
+                        container_id: c.id,
+                        writable_layer: c.writable_layer,
+                        volumes_total,
+                    }
+                })
+                .collect();
+            store.insert_container_disk_batch(time, &samples)
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(error = %e, "failed to record container storage"),
+            Err(e) => tracing::warn!(error = %e, "container storage insert task panicked"),
+        }
+    }
+}
+
+/// Prefixes a container mount source with `HOST_MOUNT_PREFIX` so Sentinel can
+/// reach host paths mounted into its own container. Mount sources are absolute,
+/// so an empty prefix leaves the path unchanged.
+fn resolve_host_path(prefix: &str, source: &str) -> PathBuf {
+    if prefix.is_empty() {
+        PathBuf::from(source)
+    } else {
+        PathBuf::from(format!("{prefix}{source}"))
+    }
+}
+
+/// Recursively sums on-disk block usage (like `du`) under `path`. Symlinks are
+/// never followed and any I/O error degrades to 0 with a warning — the walk
+/// must never crash a collection cycle.
+///
+/// `pub` so the host-only `sentinel-bench storage` harness can measure the real
+/// walk (see BENCHMARK.md §4.9); not part of any runtime API surface.
+pub fn dir_size(path: &Path) -> u64 {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "storage: cannot stat mount source");
+            return 0;
+        }
+    };
+    let ft = meta.file_type();
+    if ft.is_symlink() {
+        return 0;
+    }
+    if ft.is_file() {
+        return meta.blocks() * 512;
+    }
+    if !ft.is_dir() {
+        return 0;
+    }
+
+    let mut total = meta.blocks() * 512;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::warn!(path = %dir.display(), error = %e, "storage: cannot read directory");
+                continue;
+            }
+        };
+        for entry in entries.flatten() {
+            // DirEntry::metadata does not traverse symlinks, so symlinked
+            // entries report their own (tiny) size and are not recursed into.
+            let md = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let ft = md.file_type();
+            if ft.is_dir() {
+                total += md.blocks() * 512;
+                stack.push(entry.path());
+            } else if ft.is_file() {
+                total += md.blocks() * 512;
+            }
+        }
+    }
+    total
+}
+
+/// Snapshot every real filesystem, one `DiskSample` per unique mountpoint.
+/// Pseudo/virtual filesystems and zero-capacity devices are skipped.
+///
+/// `pub` for the host-only `sentinel-bench storage` harness (BENCHMARK.md §4.9).
+pub fn sample_disks() -> Vec<DiskSample> {
+    let disks = Disks::new_with_refreshed_list();
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for d in disks.list() {
+        let fs = d.file_system().to_string_lossy();
+        if is_pseudo_fs(&fs) {
+            continue;
+        }
+        let total = d.total_space();
+        if total == 0 {
+            continue;
+        }
+        let mount = d.mount_point().to_string_lossy().to_string();
+        if !seen.insert(mount.clone()) {
+            continue;
+        }
+        let available = d.available_space();
+        let used = total.saturating_sub(available);
+        let used_percent = used as f64 / total as f64 * 100.0;
+        out.push(DiskSample {
+            mount,
+            total,
+            used,
+            available,
+            used_percent,
+        });
+    }
+    out
+}
+
+/// Kernel/pseudo filesystems that carry no meaningful capacity for a server
+/// storage view (tmpfs, overlay, cgroup mounts, …).
+fn is_pseudo_fs(fs: &str) -> bool {
+    matches!(
+        fs,
+        "" | "tmpfs"
+            | "devtmpfs"
+            | "overlay"
+            | "overlayfs"
+            | "squashfs"
+            | "proc"
+            | "sysfs"
+            | "cgroup"
+            | "cgroup2"
+            | "mqueue"
+            | "devpts"
+            | "ramfs"
+            | "nsfs"
+            | "tracefs"
+            | "debugfs"
+            | "autofs"
+            | "binfmt_misc"
+            | "fusectl"
+            | "configfs"
+            | "securityfs"
+            | "pstore"
+            | "bpf"
+            | "hugetlbfs"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_host_path_with_and_without_prefix() {
+        assert_eq!(
+            resolve_host_path("", "/var/lib/docker/volumes/x/_data"),
+            PathBuf::from("/var/lib/docker/volumes/x/_data")
+        );
+        assert_eq!(
+            resolve_host_path("/host", "/var/lib/docker/volumes/x/_data"),
+            PathBuf::from("/host/var/lib/docker/volumes/x/_data")
+        );
+    }
+
+    #[test]
+    fn pseudo_filesystems_are_skipped() {
+        assert!(is_pseudo_fs("tmpfs"));
+        assert!(is_pseudo_fs("overlay"));
+        assert!(is_pseudo_fs("cgroup2"));
+        assert!(is_pseudo_fs(""));
+        assert!(!is_pseudo_fs("ext4"));
+        assert!(!is_pseudo_fs("xfs"));
+        assert!(!is_pseudo_fs("btrfs"));
+    }
+
+    #[test]
+    fn dir_size_missing_path_is_zero() {
+        assert_eq!(dir_size(Path::new("/nonexistent/sentinel/storage/path")), 0);
+    }
+
+    #[test]
+    fn dir_size_sums_file_blocks() {
+        let dir =
+            std::env::temp_dir().join(format!("sentinel-storage-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        std::fs::write(dir.join("a.bin"), vec![0u8; 8192]).unwrap();
+        std::fs::write(dir.join("sub/b.bin"), vec![0u8; 4096]).unwrap();
+        // At least the two files' worth of blocks (12 KiB) must be counted.
+        assert!(dir_size(&dir) >= 12 * 1024);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/collector/src/storage.rs
+++ b/crates/collector/src/storage.rs
@@ -341,8 +341,7 @@ mod tests {
 
     #[test]
     fn dir_size_bounded_stops_at_entry_cap() {
-        let dir =
-            std::env::temp_dir().join(format!("sentinel-storage-cap-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("sentinel-storage-cap-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         // A flat directory of ten one-block files. Each contributes >0 blocks

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -50,6 +50,11 @@ pub struct Config {
     pub collector_enabled: bool,
     pub collector_retention_period_days: u32,
     pub bind_addr: SocketAddr,
+    pub storage_enabled: bool,
+    pub storage_refresh_rate_seconds: u64,
+    pub storage_volumes_enabled: bool,
+    pub storage_volumes_refresh_rate_seconds: u64,
+    pub host_mount_prefix: String,
 }
 
 impl Config {
@@ -67,6 +72,13 @@ impl Config {
         let collector_retention_period_days =
             u32::try_from(positive_from_env("COLLECTOR_RETENTION_PERIOD_DAYS", 7)?)
                 .map_err(|_| ConfigError::NotPositive("COLLECTOR_RETENTION_PERIOD_DAYS"))?;
+
+        let storage_enabled = bool_from_env("STORAGE_ENABLED", true)?;
+        let storage_refresh_rate_seconds = positive_from_env("STORAGE_REFRESH_RATE_SECONDS", 300)?;
+        let storage_volumes_enabled = bool_from_env("STORAGE_VOLUMES_ENABLED", true)?;
+        let storage_volumes_refresh_rate_seconds =
+            positive_from_env("STORAGE_VOLUMES_REFRESH_RATE_SECONDS", 900)?;
+        let host_mount_prefix = non_empty("HOST_MOUNT_PREFIX").unwrap_or_default();
 
         let port: u16 = match non_empty("PORT") {
             None => 8888,
@@ -112,6 +124,11 @@ impl Config {
             collector_enabled,
             collector_retention_period_days,
             bind_addr,
+            storage_enabled,
+            storage_refresh_rate_seconds,
+            storage_volumes_enabled,
+            storage_volumes_refresh_rate_seconds,
+            host_mount_prefix,
         })
     }
 
@@ -131,6 +148,11 @@ impl Config {
             collector_enabled: false,
             collector_retention_period_days: 7,
             bind_addr: SocketAddr::from(([127, 0, 0, 1], 8888)),
+            storage_enabled: false,
+            storage_refresh_rate_seconds: 300,
+            storage_volumes_enabled: false,
+            storage_volumes_refresh_rate_seconds: 900,
+            host_mount_prefix: String::new(),
         }
     }
 }
@@ -310,6 +332,8 @@ mod tests {
             "PUSH_INTERVAL_SECONDS",
             "COLLECTOR_REFRESH_RATE_SECONDS",
             "COLLECTOR_RETENTION_PERIOD_DAYS",
+            "STORAGE_REFRESH_RATE_SECONDS",
+            "STORAGE_VOLUMES_REFRESH_RATE_SECONDS",
         ] {
             let _l = env_lock().lock().unwrap();
             let _g = EnvGuard::set(&[
@@ -375,6 +399,11 @@ mod tests {
             ("PUSH_INTERVAL_SECONDS", ""),
             ("COLLECTOR_REFRESH_RATE_SECONDS", ""),
             ("COLLECTOR_RETENTION_PERIOD_DAYS", ""),
+            ("STORAGE_ENABLED", ""),
+            ("STORAGE_REFRESH_RATE_SECONDS", ""),
+            ("STORAGE_VOLUMES_ENABLED", ""),
+            ("STORAGE_VOLUMES_REFRESH_RATE_SECONDS", ""),
+            ("HOST_MOUNT_PREFIX", ""),
         ]);
         let c = Config::load(false).unwrap();
         assert_eq!(c.refresh_rate_seconds, 5);
@@ -384,6 +413,13 @@ mod tests {
         assert!(!c.debug);
         assert_eq!(c.bind_addr.port(), 8888);
         assert_eq!(c.metrics_file.to_str().unwrap(), "/app/db/metrics.sqlite");
+        // Storage collection defaults on; the expensive volume walk too, but is
+        // inert until host paths are mounted (see HOST_MOUNT_PREFIX).
+        assert!(c.storage_enabled);
+        assert_eq!(c.storage_refresh_rate_seconds, 300);
+        assert!(c.storage_volumes_enabled);
+        assert_eq!(c.storage_volumes_refresh_rate_seconds, 900);
+        assert_eq!(c.host_mount_prefix, "");
     }
 
     #[test]

--- a/crates/docker/src/lib.rs
+++ b/crates/docker/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod calc;
 pub mod model;
 
-pub use model::{ContainerStats, ContainerSummary};
+pub use model::{ContainerDisk, ContainerStats, ContainerSummary};
 
 use bollard::Docker;
 use bollard::query_parameters::{InspectContainerOptions, ListContainersOptions, StatsOptions};
@@ -56,6 +56,37 @@ impl DockerClient {
                 // renamed a variant. See the wire-string test below.
                 state: c.state.map(|s| s.to_string()).unwrap_or_default(),
                 labels: c.labels.unwrap_or_default(),
+            })
+            .collect())
+    }
+
+    /// Lists all containers with `size: true`, yielding each container's
+    /// writable-layer size (`SizeRw`) and mount source paths in one API call.
+    /// `size: true` makes the daemon compute per-container sizes, so this is
+    /// heavier than `list_containers` and runs on the slower storage ticker.
+    pub async fn list_container_sizes(&self) -> Result<Vec<ContainerDisk>, DockerError> {
+        let opts = ListContainersOptions {
+            all: true,
+            size: true,
+            ..Default::default()
+        };
+        let raw = self.inner.list_containers(Some(opts)).await?;
+        Ok(raw
+            .into_iter()
+            .map(|c| {
+                let mount_sources = c
+                    .mounts
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|m| m.source.filter(|s| !s.is_empty()))
+                    .collect();
+                ContainerDisk {
+                    id: c.id.unwrap_or_default(),
+                    // SizeRw is Option<i64>; a missing or negative value means
+                    // "unknown", recorded as 0.
+                    writable_layer: c.size_rw.filter(|v| *v >= 0).unwrap_or(0) as u64,
+                    mount_sources,
+                }
             })
             .collect())
     }

--- a/crates/docker/src/lib.rs
+++ b/crates/docker/src/lib.rs
@@ -171,7 +171,9 @@ fn container_disk_from_summary(c: bollard::models::ContainerSummary) -> Containe
 #[cfg(test)]
 mod tests {
     use super::container_disk_from_summary;
-    use bollard::models::{ContainerSummary, ContainerSummaryStateEnum, HealthStatusEnum, MountPoint};
+    use bollard::models::{
+        ContainerSummary, ContainerSummaryStateEnum, HealthStatusEnum, MountPoint,
+    };
 
     // A `size: true` list yields the raw Docker id, but the disk series must be
     // keyed on the same display name as cpu/memory (coolify.name label, else the

--- a/crates/docker/src/lib.rs
+++ b/crates/docker/src/lib.rs
@@ -71,24 +71,7 @@ impl DockerClient {
             ..Default::default()
         };
         let raw = self.inner.list_containers(Some(opts)).await?;
-        Ok(raw
-            .into_iter()
-            .map(|c| {
-                let mount_sources = c
-                    .mounts
-                    .unwrap_or_default()
-                    .into_iter()
-                    .filter_map(|m| m.source.filter(|s| !s.is_empty()))
-                    .collect();
-                ContainerDisk {
-                    id: c.id.unwrap_or_default(),
-                    // SizeRw is Option<i64>; a missing or negative value means
-                    // "unknown", recorded as 0.
-                    writable_layer: c.size_rw.filter(|v| *v >= 0).unwrap_or(0) as u64,
-                    mount_sources,
-                }
-            })
-            .collect())
+        Ok(raw.into_iter().map(container_disk_from_summary).collect())
     }
 
     pub async fn stats(&self, id: &str) -> Result<ContainerStats, DockerError> {
@@ -162,9 +145,95 @@ impl DockerClient {
     }
 }
 
+/// Maps a `size: true` bollard container summary to our [`ContainerDisk`],
+/// keying on the display name (not the raw Docker id) so the recorded series
+/// matches the cpu/memory collector and the documented per-container disk
+/// endpoint key. Pure and Docker-free so it can be unit-tested directly.
+fn container_disk_from_summary(c: bollard::models::ContainerSummary) -> ContainerDisk {
+    let id = c.id.unwrap_or_default();
+    let names = c.names.unwrap_or_default();
+    let labels = c.labels.unwrap_or_default();
+    let mount_sources = c
+        .mounts
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|m| m.source.filter(|s| !s.is_empty()))
+        .collect();
+    ContainerDisk {
+        id: model::resolve_display_name(&labels, &names, &id),
+        // SizeRw is Option<i64>; a missing or negative value means "unknown",
+        // recorded as 0.
+        writable_layer: c.size_rw.filter(|v| *v >= 0).unwrap_or(0) as u64,
+        mount_sources,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use bollard::models::{ContainerSummaryStateEnum, HealthStatusEnum};
+    use super::container_disk_from_summary;
+    use bollard::models::{ContainerSummary, ContainerSummaryStateEnum, HealthStatusEnum, MountPoint};
+
+    // A `size: true` list yields the raw Docker id, but the disk series must be
+    // keyed on the same display name as cpu/memory (coolify.name label, else the
+    // Docker name, else id[:12]) — otherwise GET /api/container/{name}/disk/*
+    // and push correlation miss. Pin that here.
+    #[test]
+    fn container_disk_keys_on_display_name_not_raw_id() {
+        let mut labels = std::collections::HashMap::new();
+        labels.insert("coolify.name".to_string(), "postgres-db".to_string());
+        let c = ContainerSummary {
+            id: Some("a".repeat(64)),
+            names: Some(vec!["/some-generated-name".to_string()]),
+            labels: Some(labels),
+            size_rw: Some(2048),
+            mounts: Some(vec![MountPoint {
+                source: Some("/var/lib/docker/volumes/x/_data".to_string()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        };
+        let disk = container_disk_from_summary(c);
+        assert_eq!(disk.id, "postgres-db");
+        assert_eq!(disk.writable_layer, 2048);
+        assert_eq!(
+            disk.mount_sources,
+            vec!["/var/lib/docker/volumes/x/_data".to_string()]
+        );
+    }
+
+    #[test]
+    fn container_disk_falls_back_to_truncated_id_not_full_hash() {
+        let c = ContainerSummary {
+            id: Some("abcdef0123456789deadbeef".to_string()),
+            ..Default::default()
+        };
+        let disk = container_disk_from_summary(c);
+        assert_eq!(disk.id, "abcdef012345");
+    }
+
+    #[test]
+    fn container_disk_empty_source_mounts_are_dropped() {
+        let c = ContainerSummary {
+            id: Some("id".to_string()),
+            mounts: Some(vec![
+                MountPoint {
+                    source: Some(String::new()),
+                    ..Default::default()
+                },
+                MountPoint {
+                    source: None,
+                    ..Default::default()
+                },
+                MountPoint {
+                    source: Some("/data".to_string()),
+                    ..Default::default()
+                },
+            ]),
+            ..Default::default()
+        };
+        let disk = container_disk_from_summary(c);
+        assert_eq!(disk.mount_sources, vec!["/data".to_string()]);
+    }
 
     // Coolify's PushServerUpdateJob keys container status on these exact
     // lowercase strings (running / restarting / exited / paused / dead ...),

--- a/crates/docker/src/model.rs
+++ b/crates/docker/src/model.rs
@@ -28,6 +28,17 @@ impl ContainerSummary {
     }
 }
 
+/// Per-container storage inputs from a `size: true` container list.
+#[derive(Debug, Clone, Default)]
+pub struct ContainerDisk {
+    pub id: String,
+    /// Docker `SizeRw` — writable-layer bytes.
+    pub writable_layer: u64,
+    /// Host source paths of the container's volume/bind mounts. tmpfs mounts
+    /// (empty source) are excluded, so these are the paths worth `du`-walking.
+    pub mount_sources: Vec<String>,
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ContainerStats {
     pub cpu_total: u64,

--- a/crates/docker/src/model.rs
+++ b/crates/docker/src/model.rs
@@ -10,27 +10,44 @@ pub struct ContainerSummary {
 }
 
 impl ContainerSummary {
-    /// Name resolution ported from the Go collector: prefer the `coolify.name`
-    /// label, then the first Docker name with its leading '/' stripped, then a
-    /// 12-character truncation of the container id.
+    /// See [`resolve_display_name`].
     pub fn display_name(&self) -> String {
-        if let Some(n) = self.labels.get("coolify.name")
-            && !n.is_empty()
-        {
-            return n.clone();
-        }
-        if let Some(first) = self.names.first()
-            && !first.is_empty()
-        {
-            return first.trim_start_matches('/').to_string();
-        }
-        self.id.chars().take(12).collect()
+        resolve_display_name(&self.labels, &self.names, &self.id)
     }
+}
+
+/// Name resolution ported from the Go collector: prefer the `coolify.name`
+/// label, then the first Docker name with its leading '/' stripped, then a
+/// 12-character truncation of the container id.
+///
+/// Every container metric series (cpu/memory/disk) keys on this value, so the
+/// disk collector must resolve names identically to the cpu/memory collector —
+/// keying disk rows on the raw Docker id would make the per-container disk
+/// endpoints and push correlation miss on the documented display-name key.
+pub fn resolve_display_name(
+    labels: &HashMap<String, String>,
+    names: &[String],
+    id: &str,
+) -> String {
+    if let Some(n) = labels.get("coolify.name")
+        && !n.is_empty()
+    {
+        return n.clone();
+    }
+    if let Some(first) = names.first()
+        && !first.is_empty()
+    {
+        return first.trim_start_matches('/').to_string();
+    }
+    id.chars().take(12).collect()
 }
 
 /// Per-container storage inputs from a `size: true` container list.
 #[derive(Debug, Clone, Default)]
 pub struct ContainerDisk {
+    /// Container display name (see [`resolve_display_name`]), matching the key
+    /// used by the cpu/memory series — NOT the raw Docker id — so the disk
+    /// endpoints and push payload correlate on the documented display name.
     pub id: String,
     /// Docker `SizeRw` — writable-layer bytes.
     pub writable_layer: u64,

--- a/crates/push/Cargo.toml
+++ b/crates/push/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [dependencies]
 config = { path = "../config" }
 docker = { path = "../docker" }
+store = { path = "../store" }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/push/src/lib.rs
+++ b/crates/push/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use config::Config;
 use docker::DockerClient;
 use serde::Serialize;
+use store::Store;
 use time::format_description::well_known::Rfc3339;
 use tokio::sync::watch;
 use tokio::task::JoinSet;
@@ -54,11 +55,12 @@ pub fn snapshot_metadata(inspection_failures: usize) -> serde_json::Value {
 pub struct Pusher {
     config: Arc<Config>,
     docker: DockerClient,
+    store: Store,
     client: reqwest::Client,
 }
 
 impl Pusher {
-    pub fn new(config: Arc<Config>, docker: DockerClient) -> Result<Self, PushError> {
+    pub fn new(config: Arc<Config>, docker: DockerClient, store: Store) -> Result<Self, PushError> {
         let client = reqwest::Client::builder()
             .pool_max_idle_per_host(100)
             .pool_idle_timeout(std::time::Duration::from_secs(90))
@@ -67,6 +69,7 @@ impl Pusher {
         Ok(Self {
             config,
             docker,
+            store,
             client,
         })
     }
@@ -129,15 +132,73 @@ impl Pusher {
     pub async fn build_payload(&self) -> Result<serde_json::Value, PushError> {
         let (containers, failures) = self.container_data().await?;
         let used_percentage = fs_usage::root_used_percentage()?;
+        let (filesystem_usage, container_storage) = self.storage_data().await;
 
+        // `filesystem_usage` and `container_storage` are additive: Coolify
+        // validates only `containers` and reads other keys with data_get(), so
+        // it ignores these until updated to consume them. `filesystem_usage_root`
+        // (the frozen root-disk field) is left untouched.
         Ok(serde_json::json!({
             "containers": containers,
             "filesystem_usage_root": {
                 // Go formats this with %d into a string.
                 "used_percentage": used_percentage.to_string(),
             },
+            "filesystem_usage": filesystem_usage,
+            "container_storage": container_storage,
             "snapshot": snapshot_metadata(failures),
         }))
+    }
+
+    /// Reads the latest stored storage rows (never samples live — the `du`-walk
+    /// only runs on the storage collector's own cadence). A read failure logs
+    /// and contributes empty arrays rather than failing the whole push.
+    async fn storage_data(&self) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+        let store = self.store.clone();
+        let (disks, containers) = match tokio::task::spawn_blocking(move || {
+            (store.disk_latest(), store.container_disk_latest())
+        })
+        .await
+        {
+            Ok((d, c)) => (
+                d.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "failed to read disk usage for push");
+                    Vec::new()
+                }),
+                c.unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "failed to read container storage for push");
+                    Vec::new()
+                }),
+            ),
+            Err(e) => {
+                tracing::warn!(error = %e, "storage read task panicked");
+                (Vec::new(), Vec::new())
+            }
+        };
+
+        let filesystem_usage = disks
+            .iter()
+            .map(|d| {
+                serde_json::json!({
+                    "mount": d.mount,
+                    "total": d.total,
+                    "used": d.used,
+                    "available": d.available,
+                    "usedPercent": d.used_percent,
+                })
+            })
+            .collect();
+        let container_storage = containers
+            .iter()
+            .map(|c| {
+                serde_json::json!({
+                    "id": c.container_id,
+                    "writableLayer": c.writable_layer,
+                    "volumesTotal": c.volumes_total,
+                })
+            })
+            .collect();
+        (filesystem_usage, container_storage)
     }
 
     async fn container_data(&self) -> Result<(Vec<Container>, usize), PushError> {

--- a/crates/sentinel-bench/Cargo.toml
+++ b/crates/sentinel-bench/Cargo.toml
@@ -11,6 +11,8 @@ name = "sentinel-bench"
 path = "src/main.rs"
 
 [dependencies]
+collector = { path = "../collector" }
+store = { path = "../store" }
 clap = { version = "4", features = ["derive", "env"] }
 futures-util.workspace = true
 reqwest.workspace = true

--- a/crates/sentinel-bench/src/main.rs
+++ b/crates/sentinel-bench/src/main.rs
@@ -9,6 +9,7 @@
 
 #![forbid(unsafe_code)]
 
+mod storage_bench;
 mod sysinfo_report;
 
 use std::sync::Arc;
@@ -47,6 +48,8 @@ enum Command {
     Load(LoadOpts),
     /// Stress: high concurrency, mixed endpoints, optional ramp/burst/soak.
     Stress(StressOpts),
+    /// Storage-feature micro-bench: du-walk, disk sampling, store writes, downsample.
+    Storage(StorageCli),
     /// Run latency + load + stress with shared target options.
     Suite {
         #[command(flatten)]
@@ -133,6 +136,34 @@ struct StressOpts {
     health_every_secs: u64,
 }
 
+#[derive(Parser, Debug)]
+struct StorageCli {
+    /// Directory to build the synthetic tree under (a unique subdir is created).
+    #[arg(long, default_value = "/tmp")]
+    tree_dir: String,
+    /// Child directories per directory level.
+    #[arg(long, default_value_t = 4)]
+    breadth: usize,
+    /// Nesting depth of the synthetic tree.
+    #[arg(long, default_value_t = 4)]
+    depth: usize,
+    /// Regular files per directory.
+    #[arg(long, default_value_t = 8)]
+    files_per_dir: usize,
+    /// Bytes per synthetic file.
+    #[arg(long, default_value_t = 4096)]
+    file_bytes: usize,
+    /// Keep the synthetic tree after the run instead of deleting it.
+    #[arg(long, default_value_t = false)]
+    keep: bool,
+    /// Total rows for the store write / downsample phases.
+    #[arg(long, default_value_t = 100_000)]
+    rows: usize,
+    /// Use larger, worst-case parameters (deep+wide tree, more rows).
+    #[arg(long, default_value_t = false)]
+    stress: bool,
+}
+
 #[derive(Clone, Copy)]
 struct Endpoint {
     path: &'static str,
@@ -170,6 +201,16 @@ const ENDPOINTS: &[Endpoint] = &[
     },
     Endpoint {
         path: "/api/memory/history",
+        weight: 2,
+        latency_n: 40,
+    },
+    Endpoint {
+        path: "/api/disk/current",
+        weight: 3,
+        latency_n: 80,
+    },
+    Endpoint {
+        path: "/api/disk/history",
         weight: 2,
         latency_n: 40,
     },
@@ -426,7 +467,11 @@ async fn run_load(opts: &LoadOpts) -> Result<(), Box<dyn std::error::Error>> {
         .filter(|e| {
             matches!(
                 e.path,
-                "/api/health" | "/api/cpu/current" | "/api/memory/current" | "/api/cpu/history"
+                "/api/health"
+                    | "/api/cpu/current"
+                    | "/api/memory/current"
+                    | "/api/cpu/history"
+                    | "/api/disk/current"
             )
         })
         .map(|e| e.path)
@@ -709,6 +754,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Load(l) => run_load(&l).await?,
         Command::Stress(s) => {
             stress_pass = run_stress(&s).await?;
+        }
+        Command::Storage(s) => {
+            let opts = storage_bench::StorageOpts {
+                tree_dir: std::path::PathBuf::from(s.tree_dir),
+                breadth: s.breadth,
+                depth: s.depth,
+                files_per_dir: s.files_per_dir,
+                file_bytes: s.file_bytes,
+                keep: s.keep,
+                rows: s.rows,
+                stress: s.stress,
+            };
+            // CPU/IO-bound and blocking, but nothing else runs concurrently in
+            // this one-shot tool, so a direct call is fine.
+            storage_bench::run(&opts)?;
         }
         Command::Suite {
             target,

--- a/crates/sentinel-bench/src/storage_bench.rs
+++ b/crates/sentinel-bench/src/storage_bench.rs
@@ -194,9 +194,9 @@ pub fn run(opts: &StorageOpts) -> Result<(), Box<dyn std::error::Error>> {
     println!("\n[C] store batch inserts (in-memory SQLite)");
     let store = Store::open_in_memory()?;
 
-    // Disk: 8 mounts/cycle is a realistic server; push `rows` total.
+    // Disk: 8 mounts/cycle is a realistic server; insert exactly `rows` total,
+    // with a partial final batch so the executed workload matches `--rows`.
     let mounts_per_cycle = 8usize;
-    let disk_cycles = (opts.rows / mounts_per_cycle).max(1);
     let disk_batch: Vec<DiskSample> = (0..mounts_per_cycle)
         .map(|m| DiskSample {
             mount: format!("/mnt/d{m}"),
@@ -207,11 +207,16 @@ pub fn run(opts: &StorageOpts) -> Result<(), Box<dyn std::error::Error>> {
         })
         .collect();
     let t = Instant::now();
-    for cycle in 0..disk_cycles {
-        store.insert_disk_batch(cycle as i64 * 1000, &disk_batch)?;
+    let mut disk_rows = 0usize;
+    let mut cycle = 0i64;
+    while disk_rows < opts.rows {
+        let n = (opts.rows - disk_rows).min(mounts_per_cycle);
+        store.insert_disk_batch(cycle * 1000, &disk_batch[..n])?;
+        disk_rows += n;
+        cycle += 1;
     }
     let disk_elapsed = t.elapsed();
-    let disk_rows = (disk_cycles * mounts_per_cycle) as f64;
+    let disk_rows = disk_rows as f64;
     println!(
         "    disk_usage: {} rows in {:.2}s → {:.0} rows/s",
         disk_rows as u64,
@@ -219,9 +224,9 @@ pub fn run(opts: &StorageOpts) -> Result<(), Box<dyn std::error::Error>> {
         disk_rows / disk_elapsed.as_secs_f64().max(1e-9),
     );
 
-    // Container: 100 containers/cycle.
+    // Container: 100 containers/cycle; insert exactly `rows` total, with a
+    // partial final batch so the executed workload matches `--rows`.
     let cont_per_cycle = 100usize;
-    let cont_cycles = (opts.rows / cont_per_cycle).max(1);
     let cont_batch: Vec<ContainerDiskSample> = (0..cont_per_cycle)
         .map(|c| ContainerDiskSample {
             container_id: format!("container-{c:04}"),
@@ -230,11 +235,16 @@ pub fn run(opts: &StorageOpts) -> Result<(), Box<dyn std::error::Error>> {
         })
         .collect();
     let t = Instant::now();
-    for cycle in 0..cont_cycles {
-        store.insert_container_disk_batch(cycle as i64 * 1000, &cont_batch)?;
+    let mut cont_rows = 0usize;
+    let mut cycle = 0i64;
+    while cont_rows < opts.rows {
+        let n = (opts.rows - cont_rows).min(cont_per_cycle);
+        store.insert_container_disk_batch(cycle * 1000, &cont_batch[..n])?;
+        cont_rows += n;
+        cycle += 1;
     }
     let cont_elapsed = t.elapsed();
-    let cont_rows = (cont_cycles * cont_per_cycle) as f64;
+    let cont_rows = cont_rows as f64;
     println!(
         "    container_disk_usage: {} rows in {:.2}s → {:.0} rows/s",
         cont_rows as u64,
@@ -257,11 +267,17 @@ pub fn run(opts: &StorageOpts) -> Result<(), Box<dyn std::error::Error>> {
         collapsed as f64 / ds_elapsed.as_secs_f64().max(1e-9),
     );
 
-    // Cleanup
+    // Cleanup. Propagate removal failures so a leftover tree never reports OK.
+    // (A tree left behind by an earlier `?` failure is intentional: it aids
+    // debugging of a crashed run and is cleared by the next run's pre-clean.)
     if opts.keep {
         println!("\ntree kept at {}", root.display());
     } else {
-        let _ = std::fs::remove_dir_all(&root);
+        match std::fs::remove_dir_all(&root) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
     }
 
     println!("\nstorage_bench=OK");

--- a/crates/sentinel-bench/src/storage_bench.rs
+++ b/crates/sentinel-bench/src/storage_bench.rs
@@ -1,0 +1,269 @@
+//! Storage-feature micro-benchmark (BENCHMARK.md §4.9).
+//!
+//! Unlike the HTTP modes, this measures the *collector-side* cost of the
+//! storage feature — the part with no HTTP surface and the real "does it hurt
+//! system usage?" risk:
+//!   1. `du`-walk throughput over a synthetic directory tree (`collector::storage::dir_size`)
+//!   2. `sample_disks` cost against the host's real mountpoints
+//!   3. store batch-insert throughput for disk + container_disk rows
+//!   4. `downsample` cost over a large aged dataset
+//!
+//! It drives the *real* production functions, not copies, so numbers track the
+//! shipped code. Host-only; never built into the Docker image.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use collector::storage::{dir_size, sample_disks};
+use store::{ContainerDiskSample, DiskSample, Store};
+
+#[derive(Debug, Clone)]
+pub struct StorageOpts {
+    /// Directory to build the synthetic tree under (a unique subdir is created).
+    pub tree_dir: PathBuf,
+    /// Child directories per directory level.
+    pub breadth: usize,
+    /// Nesting depth of the synthetic tree.
+    pub depth: usize,
+    /// Regular files per directory.
+    pub files_per_dir: usize,
+    /// Bytes per synthetic file.
+    pub file_bytes: usize,
+    /// Keep the synthetic tree after the run instead of deleting it.
+    pub keep: bool,
+    /// Total rows for the store write / downsample phases.
+    pub rows: usize,
+    /// Use larger, worst-case parameters (deep+wide tree, more rows).
+    pub stress: bool,
+}
+
+impl StorageOpts {
+    /// Apply the stress preset unless the user overrode the shape explicitly.
+    fn effective(&self) -> StorageOpts {
+        if !self.stress {
+            return self.clone();
+        }
+        // ~3.9k dirs × 20 files ≈ 78k files (~305 MiB) — ~10× the default file
+        // count for a real worst-case walk that still completes in ~1s and a few
+        // hundred MiB, plus a 1M-row store/downsample burst.
+        StorageOpts {
+            breadth: self.breadth.max(5),
+            depth: self.depth.max(5),
+            files_per_dir: self.files_per_dir.max(20),
+            rows: self.rows.max(1_000_000),
+            ..self.clone()
+        }
+    }
+}
+
+struct Built {
+    dirs: u64,
+    files: u64,
+    logical_bytes: u64,
+}
+
+/// Recursively materialise a tree of `breadth^depth` directories, each holding
+/// `files_per_dir` files of `file_bytes` zero bytes.
+fn build_tree(root: &Path, opts: &StorageOpts) -> std::io::Result<Built> {
+    let buf = vec![0u8; opts.file_bytes];
+    let mut built = Built {
+        dirs: 0,
+        files: 0,
+        logical_bytes: 0,
+    };
+    build_level(root, opts.depth, opts, &buf, &mut built)?;
+    Ok(built)
+}
+
+fn build_level(
+    dir: &Path,
+    depth: usize,
+    opts: &StorageOpts,
+    buf: &[u8],
+    built: &mut Built,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    built.dirs += 1;
+    for f in 0..opts.files_per_dir {
+        let path = dir.join(format!("f{f}.bin"));
+        std::fs::write(&path, buf)?;
+        built.files += 1;
+        built.logical_bytes += buf.len() as u64;
+    }
+    if depth > 0 {
+        for b in 0..opts.breadth {
+            build_level(&dir.join(format!("d{b}")), depth - 1, opts, buf, built)?;
+        }
+    }
+    Ok(())
+}
+
+fn fmt_bytes(b: u64) -> String {
+    const U: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    let mut v = b as f64;
+    let mut i = 0;
+    while v >= 1024.0 && i < U.len() - 1 {
+        v /= 1024.0;
+        i += 1;
+    }
+    format!("{v:.2} {}", U[i])
+}
+
+fn min_avg_max(samples: &[Duration]) -> (Duration, Duration, Duration) {
+    let min = samples.iter().copied().min().unwrap_or_default();
+    let max = samples.iter().copied().max().unwrap_or_default();
+    let sum: Duration = samples.iter().sum();
+    let avg = sum / samples.len().max(1) as u32;
+    (min, avg, max)
+}
+
+pub fn run(opts: &StorageOpts) -> Result<(), Box<dyn std::error::Error>> {
+    let opts = opts.effective();
+    println!("=== Storage collection micro-benchmark ===");
+    println!(
+        "mode={} tree(breadth={} depth={} files/dir={} file_bytes={}) rows={}",
+        if opts.stress { "stress" } else { "default" },
+        opts.breadth,
+        opts.depth,
+        opts.files_per_dir,
+        opts.file_bytes,
+        opts.rows
+    );
+
+    // Unique tree root so parallel runs / leftovers never collide.
+    let root = opts
+        .tree_dir
+        .join(format!("sentinel-bench-storage-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+
+    // ---- Phase A: du-walk throughput ----
+    println!("\n[A] du-walk (collector::storage::dir_size)");
+    let t0 = Instant::now();
+    let built = build_tree(&root, &opts)?;
+    let build_elapsed = t0.elapsed();
+    println!(
+        "    built {} dirs, {} files, {} logical in {:.2}s",
+        built.dirs,
+        built.files,
+        fmt_bytes(built.logical_bytes),
+        build_elapsed.as_secs_f64()
+    );
+
+    let iters = 5;
+    let mut walk_samples = Vec::with_capacity(iters);
+    let mut on_disk = 0u64;
+    for _ in 0..iters {
+        let t = Instant::now();
+        on_disk = dir_size(&root);
+        walk_samples.push(t.elapsed());
+    }
+    let (wmin, wavg, wmax) = min_avg_max(&walk_samples);
+    let avg_s = wavg.as_secs_f64().max(1e-9);
+    println!(
+        "    on-disk={}  walks(n={iters}) min={:.2}ms avg={:.2}ms max={:.2}ms",
+        fmt_bytes(on_disk),
+        wmin.as_secs_f64() * 1000.0,
+        wavg.as_secs_f64() * 1000.0,
+        wmax.as_secs_f64() * 1000.0,
+    );
+    println!(
+        "    throughput: {:.0} files/s, {}/s (avg walk)",
+        built.files as f64 / avg_s,
+        fmt_bytes((built.logical_bytes as f64 / avg_s) as u64),
+    );
+
+    // ---- Phase B: sample_disks (real host mounts) ----
+    println!("\n[B] sample_disks (host filesystems)");
+    let mut s_samples = Vec::with_capacity(iters);
+    let mut n_mounts = 0;
+    for _ in 0..iters {
+        let t = Instant::now();
+        let disks = sample_disks();
+        s_samples.push(t.elapsed());
+        n_mounts = disks.len();
+    }
+    let (smin, savg, smax) = min_avg_max(&s_samples);
+    println!(
+        "    mounts={n_mounts}  n={iters} min={:.2}ms avg={:.2}ms max={:.2}ms",
+        smin.as_secs_f64() * 1000.0,
+        savg.as_secs_f64() * 1000.0,
+        smax.as_secs_f64() * 1000.0,
+    );
+
+    // ---- Phase C: store batch-insert throughput ----
+    println!("\n[C] store batch inserts (in-memory SQLite)");
+    let store = Store::open_in_memory()?;
+
+    // Disk: 8 mounts/cycle is a realistic server; push `rows` total.
+    let mounts_per_cycle = 8usize;
+    let disk_cycles = (opts.rows / mounts_per_cycle).max(1);
+    let disk_batch: Vec<DiskSample> = (0..mounts_per_cycle)
+        .map(|m| DiskSample {
+            mount: format!("/mnt/d{m}"),
+            total: 1_000_000_000,
+            used: 500_000_000,
+            available: 500_000_000,
+            used_percent: 50.0,
+        })
+        .collect();
+    let t = Instant::now();
+    for cycle in 0..disk_cycles {
+        store.insert_disk_batch(cycle as i64 * 1000, &disk_batch)?;
+    }
+    let disk_elapsed = t.elapsed();
+    let disk_rows = (disk_cycles * mounts_per_cycle) as f64;
+    println!(
+        "    disk_usage: {} rows in {:.2}s → {:.0} rows/s",
+        disk_rows as u64,
+        disk_elapsed.as_secs_f64(),
+        disk_rows / disk_elapsed.as_secs_f64().max(1e-9),
+    );
+
+    // Container: 100 containers/cycle.
+    let cont_per_cycle = 100usize;
+    let cont_cycles = (opts.rows / cont_per_cycle).max(1);
+    let cont_batch: Vec<ContainerDiskSample> = (0..cont_per_cycle)
+        .map(|c| ContainerDiskSample {
+            container_id: format!("container-{c:04}"),
+            writable_layer: 12_000_000,
+            volumes_total: 340_000_000,
+        })
+        .collect();
+    let t = Instant::now();
+    for cycle in 0..cont_cycles {
+        store.insert_container_disk_batch(cycle as i64 * 1000, &cont_batch)?;
+    }
+    let cont_elapsed = t.elapsed();
+    let cont_rows = (cont_cycles * cont_per_cycle) as f64;
+    println!(
+        "    container_disk_usage: {} rows in {:.2}s → {:.0} rows/s",
+        cont_rows as u64,
+        cont_elapsed.as_secs_f64(),
+        cont_rows / cont_elapsed.as_secs_f64().max(1e-9),
+    );
+
+    // ---- Phase D: downsample over the aged dataset just written ----
+    println!("\n[D] downsample (collapse aged rows)");
+    // The rows above were stamped at tiny timestamps (cycle*1000), so from a
+    // "now" far in the future they are all older than the 24h window.
+    let now = 400i64 * 24 * 60 * 60 * 1_000;
+    let t = Instant::now();
+    let collapsed = store.downsample(now)?;
+    let ds_elapsed = t.elapsed();
+    println!(
+        "    collapsed {} aged rows in {:.2}s → {:.0} rows/s",
+        collapsed,
+        ds_elapsed.as_secs_f64(),
+        collapsed as f64 / ds_elapsed.as_secs_f64().max(1e-9),
+    );
+
+    // Cleanup
+    if opts.keep {
+        println!("\ntree kept at {}", root.display());
+    } else {
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    println!("\nstorage_bench=OK");
+    Ok(())
+}

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -8,7 +8,9 @@ pub mod stats;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-pub use metrics::{ContainerSample, CpuRow, MemRow};
+pub use metrics::{
+    ContainerDiskRow, ContainerDiskSample, ContainerSample, CpuRow, DiskRow, DiskSample, MemRow,
+};
 pub use stats::{DbStats, TableStat};
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/store/src/metrics.rs
+++ b/crates/store/src/metrics.rs
@@ -1,4 +1,5 @@
 use crate::{Store, StoreError};
+use rusqlite::OptionalExtension;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CpuRow {
@@ -27,8 +28,48 @@ pub struct ContainerSample {
     pub mem_free: u64,
 }
 
+/// Server filesystem usage, one row per real mountpoint per cycle.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiskRow {
+    pub time: i64,
+    pub mount: String,
+    pub total: u64,
+    pub used: u64,
+    pub available: u64,
+    pub used_percent: f64,
+}
+
+/// Collector input for a single mountpoint (time is stamped once per cycle).
+#[derive(Debug, Clone, PartialEq)]
+pub struct DiskSample {
+    pub mount: String,
+    pub total: u64,
+    pub used: u64,
+    pub available: u64,
+    pub used_percent: f64,
+}
+
+/// Per-container storage: Docker writable-layer size + summed volume/bind sizes.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContainerDiskRow {
+    pub time: i64,
+    pub container_id: String,
+    pub writable_layer: u64,
+    pub volumes_total: u64,
+}
+
+/// Collector input for a single container (time is stamped once per cycle).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContainerDiskSample {
+    pub container_id: String,
+    pub writable_layer: u64,
+    pub volumes_total: u64,
+}
+
 const CPU_COLS: &str = "time, percent";
 const MEM_COLS: &str = "time, total, available, used, used_percent, free";
+const DISK_COLS: &str = "time, mount, total, used, available, used_percent";
+const CONTAINER_DISK_COLS: &str = "time, container_id, writable_layer, volumes_total";
 
 impl Store {
     pub fn insert_cpu(&self, time: i64, percent: f64) -> Result<(), StoreError> {
@@ -173,6 +214,167 @@ impl Store {
             Ok(rows)
         })
     }
+
+    /// Batched insert of one cycle's server-disk rows, one per mountpoint.
+    pub fn insert_disk_batch(&self, time: i64, rows: &[DiskSample]) -> Result<(), StoreError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.with_conn(|c| {
+            let tx = c.unchecked_transaction()?;
+            {
+                let mut stmt = tx.prepare_cached(
+                    "INSERT OR REPLACE INTO disk_usage
+                     (time, mount, total, used, available, used_percent)
+                     VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                )?;
+                for r in rows {
+                    stmt.execute((
+                        time,
+                        &r.mount,
+                        r.total as i64,
+                        r.used as i64,
+                        r.available as i64,
+                        r.used_percent,
+                    ))?;
+                }
+            }
+            tx.commit()?;
+            Ok(())
+        })
+    }
+
+    /// Batched insert of one cycle's per-container storage rows.
+    pub fn insert_container_disk_batch(
+        &self,
+        time: i64,
+        rows: &[ContainerDiskSample],
+    ) -> Result<(), StoreError> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.with_conn(|c| {
+            let tx = c.unchecked_transaction()?;
+            {
+                let mut stmt = tx.prepare_cached(
+                    "INSERT OR REPLACE INTO container_disk_usage
+                     (time, container_id, writable_layer, volumes_total)
+                     VALUES (?1, ?2, ?3, ?4)",
+                )?;
+                for r in rows {
+                    stmt.execute((
+                        time,
+                        &r.container_id,
+                        r.writable_layer as i64,
+                        r.volumes_total as i64,
+                    ))?;
+                }
+            }
+            tx.commit()?;
+            Ok(())
+        })
+    }
+
+    /// All mounts from the most recent disk cycle (every mount in a cycle shares
+    /// one timestamp, so `MAX(time)` selects the whole latest snapshot).
+    pub fn disk_latest(&self) -> Result<Vec<DiskRow>, StoreError> {
+        self.with_reader(|c| {
+            let sql = format!(
+                "SELECT {DISK_COLS} FROM disk_usage
+                 WHERE time = (SELECT MAX(time) FROM disk_usage) ORDER BY mount ASC"
+            );
+            let mut stmt = c.prepare_cached(&sql)?;
+            let rows = stmt
+                .query_map([], map_disk_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    pub fn disk_history(&self, from: i64, to: i64) -> Result<Vec<DiskRow>, StoreError> {
+        self.with_reader(|c| {
+            let sql = format!(
+                "SELECT {DISK_COLS} FROM disk_usage
+                 WHERE time >= ?1 AND time <= ?2 ORDER BY time ASC, mount ASC"
+            );
+            let mut stmt = c.prepare_cached(&sql)?;
+            let rows = stmt
+                .query_map((from, to), map_disk_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    /// All containers from the most recent container-storage cycle.
+    pub fn container_disk_latest(&self) -> Result<Vec<ContainerDiskRow>, StoreError> {
+        self.with_reader(|c| {
+            let sql = format!(
+                "SELECT {CONTAINER_DISK_COLS} FROM container_disk_usage
+                 WHERE time = (SELECT MAX(time) FROM container_disk_usage)
+                 ORDER BY container_id ASC"
+            );
+            let mut stmt = c.prepare_cached(&sql)?;
+            let rows = stmt
+                .query_map([], map_container_disk_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    /// Latest stored storage row for a single container, if any.
+    pub fn container_disk_latest_one(
+        &self,
+        id: &str,
+    ) -> Result<Option<ContainerDiskRow>, StoreError> {
+        self.with_reader(|c| {
+            let sql = format!(
+                "SELECT {CONTAINER_DISK_COLS} FROM container_disk_usage
+                 WHERE container_id = ?1 ORDER BY time DESC LIMIT 1"
+            );
+            let mut stmt = c.prepare_cached(&sql)?;
+            let row = stmt.query_row((id,), map_container_disk_row).optional()?;
+            Ok(row)
+        })
+    }
+
+    pub fn container_disk_history(
+        &self,
+        id: &str,
+        from: i64,
+        to: i64,
+    ) -> Result<Vec<ContainerDiskRow>, StoreError> {
+        self.with_reader(|c| {
+            let sql = format!(
+                "SELECT {CONTAINER_DISK_COLS} FROM container_disk_usage
+                 WHERE container_id = ?1 AND time >= ?2 AND time <= ?3 ORDER BY time ASC"
+            );
+            let mut stmt = c.prepare_cached(&sql)?;
+            let rows = stmt
+                .query_map((id, from, to), map_container_disk_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+}
+
+fn map_disk_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<DiskRow> {
+    Ok(DiskRow {
+        time: r.get(0)?,
+        mount: r.get(1)?,
+        total: r.get::<_, i64>(2)? as u64,
+        used: r.get::<_, i64>(3)? as u64,
+        available: r.get::<_, i64>(4)? as u64,
+        used_percent: r.get(5)?,
+    })
+}
+
+fn map_container_disk_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<ContainerDiskRow> {
+    Ok(ContainerDiskRow {
+        time: r.get(0)?,
+        container_id: r.get(1)?,
+        writable_layer: r.get::<_, i64>(2)? as u64,
+        volumes_total: r.get::<_, i64>(3)? as u64,
+    })
 }
 
 fn map_mem_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<MemRow> {

--- a/crates/store/src/retention.rs
+++ b/crates/store/src/retention.rs
@@ -6,11 +6,13 @@ pub const DOWNSAMPLE_AFTER_MS: i64 = 24 * 60 * 60 * 1_000;
 /// Downsampling bucket width.
 pub const BUCKET_MS: i64 = 60_000;
 
-const TABLES: [&str; 4] = [
+const TABLES: [&str; 6] = [
     "cpu_usage",
     "memory_usage",
     "container_cpu_usage",
     "container_memory_usage",
+    "disk_usage",
+    "container_disk_usage",
 ];
 
 impl Store {
@@ -65,18 +67,36 @@ impl Store {
                 lower_bound,
                 cutoff,
             )?;
-            // Container series: bucket on (time, container_id).
-            collapsed += bucket_container(
+            // Per-entity series: bucket on (time, <entity>).
+            collapsed += bucket_entity(
                 &tx,
                 "container_cpu_usage",
+                "container_id",
                 &["percent"],
                 lower_bound,
                 cutoff,
             )?;
-            collapsed += bucket_container(
+            collapsed += bucket_entity(
                 &tx,
                 "container_memory_usage",
+                "container_id",
                 &["total", "available", "used", "used_percent", "free"],
+                lower_bound,
+                cutoff,
+            )?;
+            collapsed += bucket_entity(
+                &tx,
+                "disk_usage",
+                "mount",
+                &["total", "used", "available", "used_percent"],
+                lower_bound,
+                cutoff,
+            )?;
+            collapsed += bucket_entity(
+                &tx,
+                "container_disk_usage",
+                "container_id",
+                &["writable_layer", "volumes_total"],
                 lower_bound,
                 cutoff,
             )?;
@@ -140,9 +160,12 @@ fn bucket_host(
     Ok(raw_count as u64)
 }
 
-fn bucket_container(
+/// Like `bucket_host`, but keyed on `(time_bucket, entity)` so each distinct
+/// entity (container_id, mount, …) keeps its own one-minute averages.
+fn bucket_entity(
     tx: &rusqlite::Transaction<'_>,
     table: &str,
+    entity: &str,
     cols: &[&str],
     lower_bound: Option<i64>,
     cutoff: i64,
@@ -164,14 +187,14 @@ fn bucket_container(
     let sql = format!(
         r#"
         CREATE TEMP TABLE _ds AS
-        SELECT (time / {BUCKET_MS}) * {BUCKET_MS} AS time, container_id, {avg_list}
+        SELECT (time / {BUCKET_MS}) * {BUCKET_MS} AS time, {entity}, {avg_list}
         FROM {table} WHERE {lower_predicate} AND time < {cutoff}
-        GROUP BY time / {BUCKET_MS}, container_id;
+        GROUP BY time / {BUCKET_MS}, {entity};
 
         DELETE FROM {table} WHERE {lower_predicate} AND time < {cutoff};
 
-        INSERT OR REPLACE INTO {table} (time, container_id, {col_list})
-        SELECT time, container_id, {col_list} FROM _ds;
+        INSERT OR REPLACE INTO {table} (time, {entity}, {col_list})
+        SELECT time, {entity}, {col_list} FROM _ds;
 
         DROP TABLE _ds;
         "#

--- a/crates/store/src/schema.rs
+++ b/crates/store/src/schema.rs
@@ -37,10 +37,32 @@ CREATE TABLE IF NOT EXISTS container_memory_usage (
     PRIMARY KEY (time, container_id)
 ) STRICT;
 
+CREATE TABLE IF NOT EXISTS disk_usage (
+    time         INTEGER NOT NULL,
+    mount        TEXT    NOT NULL,
+    total        INTEGER NOT NULL,
+    used         INTEGER NOT NULL,
+    available    INTEGER NOT NULL,
+    used_percent REAL    NOT NULL,
+    PRIMARY KEY (time, mount)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS container_disk_usage (
+    time           INTEGER NOT NULL,
+    container_id   TEXT    NOT NULL,
+    writable_layer INTEGER NOT NULL,
+    volumes_total  INTEGER NOT NULL,
+    PRIMARY KEY (time, container_id)
+) STRICT;
+
 CREATE INDEX IF NOT EXISTS idx_ccu_container_time
     ON container_cpu_usage (container_id, time);
 CREATE INDEX IF NOT EXISTS idx_cmu_container_time
     ON container_memory_usage (container_id, time);
+CREATE INDEX IF NOT EXISTS idx_du_mount_time
+    ON disk_usage (mount, time);
+CREATE INDEX IF NOT EXISTS idx_cdu_container_time
+    ON container_disk_usage (container_id, time);
 
 CREATE TABLE IF NOT EXISTS sentinel_meta (
     key   TEXT PRIMARY KEY,

--- a/crates/store/src/stats.rs
+++ b/crates/store/src/stats.rs
@@ -15,7 +15,7 @@ pub struct DbStats {
 }
 
 /// (table, expression summing the byte length of every column in a row)
-const TABLE_SIZES: [(&str, &str); 4] = [
+const TABLE_SIZES: [(&str, &str); 6] = [
     (
         "cpu_usage",
         "LENGTH(CAST(time AS TEXT)) + LENGTH(CAST(percent AS TEXT))",
@@ -35,6 +35,17 @@ const TABLE_SIZES: [(&str, &str); 4] = [
         "LENGTH(CAST(time AS TEXT)) + LENGTH(container_id) + LENGTH(CAST(total AS TEXT)) + \
          LENGTH(CAST(available AS TEXT)) + LENGTH(CAST(used AS TEXT)) + \
          LENGTH(CAST(used_percent AS TEXT)) + LENGTH(CAST(free AS TEXT))",
+    ),
+    (
+        "disk_usage",
+        "LENGTH(CAST(time AS TEXT)) + LENGTH(mount) + LENGTH(CAST(total AS TEXT)) + \
+         LENGTH(CAST(used AS TEXT)) + LENGTH(CAST(available AS TEXT)) + \
+         LENGTH(CAST(used_percent AS TEXT))",
+    ),
+    (
+        "container_disk_usage",
+        "LENGTH(CAST(time AS TEXT)) + LENGTH(container_id) + \
+         LENGTH(CAST(writable_layer AS TEXT)) + LENGTH(CAST(volumes_total AS TEXT))",
     ),
 ];
 

--- a/crates/store/tests/stats.rs
+++ b/crates/store/tests/stats.rs
@@ -26,7 +26,9 @@ fn reports_row_counts_and_storage_for_every_table() {
             "cpu_usage",
             "memory_usage",
             "container_cpu_usage",
-            "container_memory_usage"
+            "container_memory_usage",
+            "disk_usage",
+            "container_disk_usage"
         ]
     );
     let cpu = stats
@@ -42,6 +44,6 @@ fn reports_zeroes_for_an_empty_database() {
     let s = Store::open_in_memory().unwrap();
     let stats = s.db_stats().unwrap();
     assert_eq!(stats.row_count, 0);
-    assert_eq!(stats.tables.len(), 4);
+    assert_eq!(stats.tables.len(), 6);
     assert!(stats.tables.iter().all(|t| t.row_count == 0));
 }

--- a/crates/store/tests/storage.rs
+++ b/crates/store/tests/storage.rs
@@ -1,0 +1,151 @@
+use store::{ContainerDiskSample, DiskSample, Store};
+
+fn disk(mount: &str, used_percent: f64) -> DiskSample {
+    DiskSample {
+        mount: mount.into(),
+        total: 100,
+        used: 60,
+        available: 40,
+        used_percent,
+    }
+}
+
+#[test]
+fn round_trips_disk_and_reports_latest_per_mount() {
+    let s = Store::open_in_memory().unwrap();
+    s.insert_disk_batch(1_000, &[disk("/", 10.0), disk("/data", 20.0)])
+        .unwrap();
+    s.insert_disk_batch(2_000, &[disk("/", 30.0), disk("/data", 40.0)])
+        .unwrap();
+
+    // History returns every stored row, ordered by (time, mount).
+    let hist = s.disk_history(0, i64::MAX).unwrap();
+    assert_eq!(hist.len(), 4);
+    assert_eq!(hist[0].time, 1_000);
+    assert_eq!(hist[0].mount, "/");
+
+    // Latest returns only the most recent cycle (time == 2000), one per mount.
+    let latest = s.disk_latest().unwrap();
+    assert_eq!(latest.len(), 2);
+    assert!(latest.iter().all(|r| r.time == 2_000));
+    let root = latest.iter().find(|r| r.mount == "/").unwrap();
+    assert!((root.used_percent - 30.0).abs() < f64::EPSILON);
+    assert_eq!(root.total, 100);
+    assert_eq!(root.used, 60);
+    assert_eq!(root.available, 40);
+}
+
+#[test]
+fn disk_insert_is_upsert_on_time_and_mount() {
+    let s = Store::open_in_memory().unwrap();
+    s.insert_disk_batch(1_000, &[disk("/", 10.0)]).unwrap();
+    s.insert_disk_batch(1_000, &[disk("/", 99.0)]).unwrap();
+    let rows = s.disk_history(0, i64::MAX).unwrap();
+    assert_eq!(rows.len(), 1);
+    assert!((rows[0].used_percent - 99.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn round_trips_container_disk_and_scopes_by_id() {
+    let s = Store::open_in_memory().unwrap();
+    let samples = vec![
+        ContainerDiskSample {
+            container_id: "web".into(),
+            writable_layer: 1_000,
+            volumes_total: 5_000,
+        },
+        ContainerDiskSample {
+            container_id: "db".into(),
+            writable_layer: 2_000,
+            volumes_total: 9_000,
+        },
+    ];
+    s.insert_container_disk_batch(1_000, &samples).unwrap();
+    s.insert_container_disk_batch(
+        2_000,
+        &[ContainerDiskSample {
+            container_id: "web".into(),
+            writable_layer: 1_500,
+            volumes_total: 6_000,
+        }],
+    )
+    .unwrap();
+
+    let web = s.container_disk_history("web", 0, i64::MAX).unwrap();
+    assert_eq!(web.len(), 2);
+    assert_eq!(web[0].writable_layer, 1_000);
+    assert_eq!(web[1].volumes_total, 6_000);
+
+    // latest_one returns the most recent row for that container
+    let latest_web = s.container_disk_latest_one("web").unwrap().unwrap();
+    assert_eq!(latest_web.time, 2_000);
+    assert_eq!(latest_web.writable_layer, 1_500);
+
+    // latest (all containers) selects only the newest cycle's rows
+    let latest = s.container_disk_latest().unwrap();
+    assert_eq!(latest.len(), 1);
+    assert_eq!(latest[0].container_id, "web");
+
+    // scoping must not leak across ids
+    assert!(s.container_disk_latest_one("nope").unwrap().is_none());
+    assert!(
+        s.container_disk_history("nope", 0, i64::MAX)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+fn empty_disk_batches_are_noops() {
+    let s = Store::open_in_memory().unwrap();
+    s.insert_disk_batch(1_000, &[]).unwrap();
+    s.insert_container_disk_batch(1_000, &[]).unwrap();
+    assert!(s.disk_latest().unwrap().is_empty());
+    assert!(s.container_disk_latest().unwrap().is_empty());
+}
+
+#[test]
+fn downsampling_collapses_aged_storage_rows_per_entity() {
+    let s = Store::open_in_memory().unwrap();
+    // Two aged rows for the same mount inside one 1-minute bucket must collapse
+    // into a single averaged row; a fresh row (< 24h old) is left untouched.
+    let now = 100 * 24 * 60 * 60 * 1_000; // 100 days, well past the 24h window
+    let aged_a = now - 40 * 24 * 60 * 60 * 1_000;
+    let aged_b = aged_a + 1_000; // same minute bucket as aged_a
+
+    s.insert_disk_batch(aged_a, &[disk("/", 10.0)]).unwrap();
+    s.insert_disk_batch(aged_b, &[disk("/", 20.0)]).unwrap();
+    s.insert_container_disk_batch(
+        aged_a,
+        &[ContainerDiskSample {
+            container_id: "web".into(),
+            writable_layer: 100,
+            volumes_total: 1_000,
+        }],
+    )
+    .unwrap();
+    s.insert_container_disk_batch(
+        aged_b,
+        &[ContainerDiskSample {
+            container_id: "web".into(),
+            writable_layer: 300,
+            volumes_total: 3_000,
+        }],
+    )
+    .unwrap();
+
+    s.downsample(now).unwrap();
+
+    let disks = s.disk_history(0, i64::MAX).unwrap();
+    assert_eq!(disks.len(), 1, "two aged disk rows collapse to one bucket");
+    assert!((disks[0].used_percent - 15.0).abs() < 0.01, "averaged");
+
+    let cds = s.container_disk_history("web", 0, i64::MAX).unwrap();
+    assert_eq!(
+        cds.len(),
+        1,
+        "two aged container rows collapse to one bucket"
+    );
+    assert_eq!(cds[0].writable_layer, 200, "integer average of 100 and 300");
+    assert_eq!(cds[0].volumes_total, 2_000);
+}

--- a/docs/benchmark-results/2026-08-09-storage-metrics.md
+++ b/docs/benchmark-results/2026-08-09-storage-metrics.md
@@ -1,0 +1,200 @@
+# Benchmark results — 2026-08-09 — storage metrics feature
+
+Feature-specific benchmark of the storage-metrics work (branch `feat/storage-metrics`):
+new `/api/disk/*` + `/api/container/{id}/disk/*` endpoints and the collector-side
+`du`-walk / disk-sampling / store-write path. Method per `BENCHMARK.md` (§4.4 latency,
+§4.6 stress, §4.9 storage micro-bench), harness `sentinel-bench` 1.0.0.
+
+> Numbers are one host, one day. Not SLOs. The storage micro-bench ran the **real** collector
+> functions (`collector::storage::dir_size` / `sample_disks`, `store::insert_*` / `downsample`).
+
+## System configuration
+```text
+=== System configuration ===
+date_utc=2026-08-09T12:02:03Z
+hostname=coder
+uname=Linux 7.0.2-3-pve x86_64
+os=Debian GNU/Linux 13 (trixie)
+arch=x86_64
+virt=lxc
+cpu_model=AMD Ryzen 7 3700X 8-Core Processor
+cpu_logical=8
+cpu_online=1,4-5,7-9,11-12
+mem_total=10.00 GiB (10485760 kB)
+mem_available=5.69 GiB (5971496 kB)
+loadavg=4.26 2.59 1.94
+cgroup_v2=true
+cgroup_cpu_max=max 100000
+cgroup_memory_max=max
+docker_server=29.7.2
+docker_info=driver=overlayfs cgroup_driver=systemd cgroup_version=2 ncpu=8 mem_total=10737418240
+harness=sentinel-bench 1.0.0
+============================
+```
+
+## Environment
+- Method: BENCHMARK.md + sentinel-bench (git `672190f` base; feature on `feat/storage-metrics`)
+- Server: `target/release/sentinel`, `SENTINEL_DEVELOPMENT=1`, `PORT=18899`, push blackhole
+  (`http://127.0.0.1:9`), `STORAGE_REFRESH_RATE_SECONDS=2`, `STORAGE_VOLUMES_REFRESH_RATE_SECONDS=5`
+- Storage micro-bench `--tree-dir` was `/tmp` (**tmpfs** on this host — walk times understate
+  seek-bound spinning/network disks; see BENCHMARK.md §4.9 caveat)
+
+## Candidate
+| Label | /api/version | Git branch |
+|-------|--------------|------------|
+| rust-storage | 1.0.0 | feat/storage-metrics |
+
+---
+
+## 1. Storage collection micro-bench (§4.9)
+
+### Default (`sentinel-bench storage`)
+```text
+mode=default tree(breadth=4 depth=4 files/dir=8 file_bytes=4096) rows=100000
+
+[A] du-walk (collector::storage::dir_size)
+    built 341 dirs, 2728 files, 10.66 MiB logical
+    on-disk=10.66 MiB  walks(n=5) min=9.19ms avg=9.64ms max=10.04ms
+    throughput: 283045 files/s, 1.08 GiB/s (avg walk)
+
+[B] sample_disks (host filesystems)
+    mounts=1  n=5 min=0.71ms avg=1.17ms max=2.75ms
+
+[C] store batch inserts (in-memory SQLite)
+    disk_usage: 100000 rows in 0.24s → 416318 rows/s
+    container_disk_usage: 100000 rows in 0.24s → 416083 rows/s
+
+[D] downsample (collapse aged rows)
+    collapsed 200000 aged rows in 0.28s → 721869 rows/s
+```
+
+### Stress (`sentinel-bench storage --stress`)
+```text
+mode=stress tree(breadth=5 depth=5 files/dir=20 file_bytes=4096) rows=1000000
+
+[A] du-walk (collector::storage::dir_size)
+    built 3906 dirs, 78120 files, 305.16 MiB logical
+    on-disk=305.16 MiB  walks(n=5) min=245.14ms avg=245.97ms max=246.74ms
+    throughput: 317598 files/s, 1.21 GiB/s (avg walk)
+
+[B] sample_disks (host filesystems)
+    mounts=1  n=5 min=0.68ms avg=0.80ms max=1.12ms
+
+[C] store batch inserts (in-memory SQLite)
+    disk_usage: 1000000 rows in 2.67s → 374011 rows/s
+    container_disk_usage: 1000000 rows in 2.95s → 339328 rows/s
+
+[D] downsample (collapse aged rows)
+    collapsed 2000000 aged rows in 3.14s → 637738 rows/s
+```
+
+| Phase | Default | Stress |
+|-------|---------|--------|
+| du-walk files | 2 728 (10.66 MiB) | 78 120 (305 MiB) |
+| du-walk avg | 9.64 ms | 245.97 ms |
+| du-walk throughput | 283k files/s · 1.08 GiB/s | 318k files/s · 1.21 GiB/s |
+| sample_disks avg | 1.17 ms | 0.80 ms |
+| disk insert | 416k rows/s | 374k rows/s |
+| container insert | 416k rows/s | 339k rows/s |
+| downsample | 722k rows/s | 638k rows/s |
+
+**Read on the "does it hurt system usage?" question (design item a):** worst-case walk of 78k
+files / 305 MiB = **~246 ms**, run once per `STORAGE_VOLUMES_REFRESH_RATE_SECONDS` (default 900 s)
+→ **~0.03 %** duty cycle, sequential, on a blocking thread. The cheap `sample_disks` (~1 ms) runs on
+the separate 300 s ticker. This is the payoff of decoupling the two intervals. Caveat: `/tmp` is
+tmpfs here, so real seek-bound disks will be slower — re-run with `--tree-dir` on the volume store
+for a production figure.
+
+---
+
+## 2. HTTP endpoints — sequential latency (§4.4)
+
+Live server, `sentinel-bench latency`. New disk endpoints in **bold**.
+
+| Endpoint | ok | avg | p50 | p95 | p99 | max |
+|----------|----|-----|-----|-----|-----|-----|
+| /api/health | 80 | 0.07 | 0.07 | 0.09 | 0.22 | 0.35 |
+| /api/version | 80 | 0.07 | 0.07 | 0.08 | 0.09 | 0.09 |
+| /api/cpu/current | 80 | 0.07 | 0.07 | 0.08 | 0.10 | 0.47 |
+| /api/memory/current | 80 | 0.06 | 0.06 | 0.07 | 0.09 | 0.11 |
+| /api/cpu/history | 40 | 0.10 | 0.09 | 0.13 | 0.24 | 0.24 |
+| /api/memory/history | 40 | 0.08 | 0.07 | 0.11 | 0.17 | 0.17 |
+| **/api/disk/current** | 80 | 0.08 | 0.08 | 0.12 | 0.15 | 0.17 |
+| **/api/disk/history** | 40 | 0.09 | 0.09 | 0.11 | 0.11 | 0.11 |
+
+Disk endpoints sit right alongside cpu/memory — no latency outlier (ms).
+
+`/api/disk/current` sample response (live, root fs):
+```json
+[{"time":"1786276894750","mount":"/","total":107374182400,"used":82882723840,"available":24491458560,"usedPercent":77.19}]
+```
+
+## 3. HTTP stress (§4.6) — traffic mix now includes disk endpoints
+
+`sentinel-bench stress --concurrency 128 --duration 10` (mixed; weights include disk/current 3,
+disk/history 2):
+
+```text
+mixed(all endpoints)  c=128 t=10s  ok=896387 fail=0 rps=89597.4
+  avg=1.44ms p50=1.22ms p95=3.12ms p99=4.08ms max=32.37ms err=0.00%
+health_probe_failures=0  post_stress_health=ok (0.29ms)  stress_result=PASS
+```
+
+- **896 387** requests, **0** errors, RPS **~89.6k**, p99 **4.08 ms**.
+- Mid-stress health probes: all OK. Post-stress `/api/health`: OK.
+
+## Memory (server, post-stress; storage collector enabled)
+| VmRSS | VmHWM | Threads |
+|-------|-------|---------|
+| 17 828 kB (~17.4 MiB) | 17 828 kB | 16 |
+
+(Dev-mode release binary in LXC after 896k requests, with the extra `StorageCollector` running —
+not a clean idle-image number; compare only to a like-for-like run.)
+
+## 4. Regression check — does the feature slow the existing endpoints?
+
+Same binary, same host, A/B on the **untouched** core endpoints (`load`, 5 s cells). Configs:
+**OFF** (`STORAGE_ENABLED=false`), **OFF#2** (repeat — establishes the run-to-run noise band on
+this busy LXC), **ON-default** (real 300 s/900 s intervals), **ON-2s** (artificial worst case:
+disk + `size:true` container list every 2 s).
+
+RPS (higher = better):
+
+| Endpoint · c | OFF | OFF#2 | ON-default | ON-2s |
+|---|---|---|---|---|
+| health c=10 | 69 802 | 67 982 | 66 535 | 64 890 |
+| health c=32 | 99 695 | 98 581 | 98 460 | 92 411 |
+| cpu/current c=10 | 65 760 | 67 084 | 67 395 | 64 492 |
+| cpu/current c=32 | 84 446 | 83 539 | 83 248 | 80 680 |
+| memory/current c=10 | 69 470 | 68 321 | 68 656 | 64 804 |
+| memory/current c=32 | 97 962 | 95 244 | 80 128* | 91 867 |
+
+Latency p99 (clean cells): ~0.40 ms @ c=10, ~0.9–1.0 ms @ c=32 — **flat across all four configs**.
+Zero errors in every cell.
+
+- **Noise floor:** OFF vs OFF#2 (identical config) already differ up to ~2.7% — that's the host's
+  run-to-run variance (shared 8-core LXC, loadavg ~4).
+- **ON-default ≈ OFF within noise.** At real intervals the storage collector's first tick is at
+  300 s, so it doesn't even fire during the load window — no measurable request-path cost.
+- **ON-2s** (150× inflated cadence) shows a small ~2–7% RPS dip at high concurrency, purely the
+  background collector + `size:true` Docker work stealing CPU under saturation — not a code-path
+  regression (latency percentiles unchanged). Gone at real cadence.
+- `*` the memory/current c=32 ON-default cell (80 128, p99 1.70 ms, max 13.1 ms) is a single
+  transient host stall in that 5 s window, not the feature (other cells for the same config are
+  normal; the collector wasn't firing).
+- **Memory:** VmRSS 12.18 MiB (OFF) → 12.85 MiB (ON-2s), +~0.67 MiB and a few threads for the
+  always-on collector task. Small and constant.
+
+**Verdict: no regression on existing endpoints at production settings.** Mechanistically expected —
+the existing handlers are unchanged, storage work runs on separate background tickers + the daily
+retention job, and API reads use the separate WAL reader connection so they never serialize behind
+storage writes. (Cold start not separately measured; the schema adds 2 idempotent `CREATE TABLE`
+statements — sub-millisecond — and `host_sampler_new_is_fast` still passes.)
+
+## Notes
+- Storage micro-bench requires no server (host-only); HTTP runs used a live dev-mode server with a
+  blackhole push endpoint.
+- `sample_disks` reported 1 mount (LXC container view) — inside a fuller host or with more mounts
+  bind-mounted in, expect one row per real filesystem.
+- To reproduce: `cargo build -p sentinel-bench --release` then `sentinel-bench storage [--stress]`
+  and the latency/stress commands in §2–§3 against a running agent.

--- a/docs/benchmark-results/README.md
+++ b/docs/benchmark-results/README.md
@@ -8,3 +8,4 @@ Every results file must include a **System configuration** block (`./target/rele
 | Date | File | Notes |
 |------|------|-------|
 | 2026-08-09 | [2026-08-09-go-vs-rust-sentinel-bench.md](2026-08-09-go-vs-rust-sentinel-bench.md) | Canonical Go vs Rust run — size/cold-start/memory/latency/load/stress (`sentinel-bench` 1.0.0) |
+| 2026-08-09 | [2026-08-09-storage-metrics.md](2026-08-09-storage-metrics.md) | Storage-metrics feature — du-walk/sampling/store micro-bench (§4.9) + disk endpoint latency/stress |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -225,6 +225,111 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/disk/current:
+    get:
+      summary: Get current disk usage
+      description: Latest stored filesystem usage, one entry per real mountpoint
+      tags:
+        - System Metrics
+      responses:
+        '200':
+          description: Current disk usage per mountpoint
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DiskUsage'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/disk/history:
+    get:
+      summary: Get disk usage history
+      description: Historical filesystem usage across mountpoints with optional date range filtering
+      tags:
+        - System Metrics
+      parameters:
+        - $ref: '#/components/parameters/FromDate'
+        - $ref: '#/components/parameters/ToDate'
+      responses:
+        '200':
+          description: Historical disk usage data
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DiskUsage'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/container/{containerId}/disk/current:
+    get:
+      summary: Get current container storage
+      description: Latest stored writable-layer and volume size for a specific container (null if none recorded)
+      tags:
+        - Container Metrics
+      parameters:
+        - name: containerId
+          in: path
+          required: true
+          description: Exact container display name recorded by Sentinel
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9._-]+$'
+          example: postgres-db
+      responses:
+        '200':
+          description: Current container storage (or null)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContainerDiskUsage'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/container/{containerId}/disk/history:
+    get:
+      summary: Get container storage history
+      description: Historical writable-layer and volume sizes for a specific container
+      tags:
+        - Container Metrics
+      parameters:
+        - name: containerId
+          in: path
+          required: true
+          description: Exact container display name recorded by Sentinel
+          schema:
+            type: string
+            pattern: '^[a-zA-Z0-9._-]+$'
+          example: postgres-db
+        - $ref: '#/components/parameters/FromDate'
+        - $ref: '#/components/parameters/ToDate'
+      responses:
+        '200':
+          description: Container storage history
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ContainerDiskUsage'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/stats:
     get:
       summary: Get database statistics
@@ -432,6 +537,66 @@ components:
           format: int64
           description: Free memory in bytes
           example: 2000000000
+        human_friendly_time:
+          type: string
+          format: date-time
+          description: ISO 8601 formatted timestamp (only in debug mode)
+          example: "2024-01-15T10:00:00Z"
+
+    DiskUsage:
+      type: object
+      properties:
+        time:
+          type: string
+          description: Unix timestamp in milliseconds
+          example: "1700000000000"
+        mount:
+          type: string
+          description: Filesystem mountpoint
+          example: "/"
+        total:
+          type: integer
+          format: int64
+          description: Total capacity in bytes
+          example: 500000000000
+        used:
+          type: integer
+          format: int64
+          description: Used space in bytes
+          example: 250000000000
+        available:
+          type: integer
+          format: int64
+          description: Available space in bytes
+          example: 250000000000
+        usedPercent:
+          type: number
+          format: float
+          description: Disk usage percentage (0-100)
+          example: 50.00
+        human_friendly_time:
+          type: string
+          format: date-time
+          description: ISO 8601 formatted timestamp (only in debug mode)
+          example: "2024-01-15T10:00:00Z"
+
+    ContainerDiskUsage:
+      type: object
+      properties:
+        time:
+          type: string
+          description: Unix timestamp in milliseconds
+          example: "1700000000000"
+        writableLayer:
+          type: integer
+          format: int64
+          description: Docker writable-layer size in bytes (SizeRw)
+          example: 12000000
+        volumesTotal:
+          type: integer
+          format: int64
+          description: Summed size in bytes of the container's volume/bind mounts
+          example: 340000000
         human_friendly_time:
           type: string
           format: date-time

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -291,7 +291,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ContainerDiskUsage'
+                nullable: true
+                allOf:
+                  - $ref: '#/components/schemas/ContainerDiskUsage'
         '401':
           $ref: '#/components/responses/UnauthorizedError'
         '500':

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,9 +178,21 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         tracing::info!("collector disabled");
     }
 
+    // Storage collector (disk usage + per-container storage)
+    if config.storage_enabled {
+        let c = collector::StorageCollector::new(config.clone(), store.clone(), docker.clone());
+        let rx = shutdown_rx.clone();
+        services.spawn(async move {
+            c.run(rx).await;
+            Ok::<(), String>(())
+        });
+    } else {
+        tracing::info!("storage collector disabled");
+    }
+
     // Pusher
     {
-        let pusher = push::Pusher::new(config.clone(), docker.clone())?;
+        let pusher = push::Pusher::new(config.clone(), docker.clone(), store.clone())?;
         let rx = shutdown_rx.clone();
         services.spawn(async move {
             pusher.run(rx).await;


### PR DESCRIPTION
## Summary
- Add a `StorageCollector` that samples per-mount filesystem usage (`sample_disks`) and per-container Docker writable-layer + volume sizes (`dir_size` `du`-walk) on independent configurable cadences, so the expensive volume walk never rides the fast disk-stat tick
- Add new endpoints: `GET /api/disk/current`, `GET /api/disk/history`, `GET /api/container/:containerId/disk/current`, `GET /api/container/:containerId/disk/history`
- Persist storage data in two new SQLite tables (`disk_usage`, `container_disk_usage`) with downsampling/retention support matching existing metrics tables
- Include disk and container storage snapshots in the Coolify push payload (`filesystem_usage`, `container_storage`) as additive fields
- Add config: `STORAGE_ENABLED`, `STORAGE_REFRESH_RATE_SECONDS`, `STORAGE_VOLUMES_ENABLED`, `STORAGE_VOLUMES_REFRESH_RATE_SECONDS`, `HOST_MOUNT_PREFIX`
- Add a `sentinel-bench storage` micro-benchmark for the collector-side du-walk/disk-sampling/store-write path, plus results in `docs/benchmark-results/`
- Update `API.md`, `README.md`, `BENCHMARK.md`, and `openapi.yaml` for the new endpoints and env vars
