### PR TITLE
feat(traffic): add /api/traffic/series endpoints for time-series charts

### DIFF
--- a/API.md
+++ b/API.md
@@ -692,6 +692,58 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 
 ---
 
+### Get App Status-Class Time Series
+
+Per-bucket request counts by HTTP status class for one app, for charting. The response is a fixed-length, zero-filled array: 24 hourly buckets for `range=24h`, and 7 or 30 daily buckets for `range=7d`/`range=30d`.
+
+**Endpoint:** `GET /api/app/:uuid/traffic/series`
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `uuid` | string | Yes | Coolify app UUID (or host, for Caddy) |
+
+**Query Parameters:**
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `range` | string | No | `24h` | Window + granularity: `24h` (hourly), `7d`/`30d` (daily) |
+
+Each element is `{ "bucket", "s2xx", "s3xx", "s4xx", "s5xx" }`, where `bucket` is the unix-millis start of the bucket. An app with no data in range returns a `200` with every bucket zeroed, not a `404`.
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:8888/api/app/jc4wsgs/traffic/series?range=24h"
+```
+
+```json
+[
+  { "bucket": 1723334400000, "s2xx": 42, "s3xx": 3, "s4xx": 1, "s5xx": 0 },
+  { "bucket": 1723338000000, "s2xx": 0, "s3xx": 0, "s4xx": 0, "s5xx": 0 }
+]
+```
+
+---
+
+### Get Server-Wide Status-Class Time Series
+
+Same shape as [Get App Status-Class Time Series](#get-app-status-class-time-series), merged across **every app and host** on the box.
+
+**Endpoint:** `GET /api/traffic/series`
+
+**Query Parameters:**
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `range` | string | No | `24h` | Window + granularity: `24h` (hourly), `7d`/`30d` (daily) |
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:8888/api/traffic/series?range=7d"
+```
+
+---
+
 ### Get GeoIP Attribution
 
 Retrieve the license attribution string for whichever GeoIP data source is currently active, so it can be surfaced in a UI.

--- a/crates/api/src/routes/traffic.rs
+++ b/crates/api/src/routes/traffic.rs
@@ -15,6 +15,7 @@ use traffic::sketches::{LatencyDigest, Uniques};
 
 use crate::AppState;
 use crate::routes::cpu::{HistoryQuery, internal_error, resolve_range};
+use crate::time::now_ms;
 use crate::types::{
     ErrorBody, TrafficAttribution, TrafficBreakdownEntry, TrafficLatency, TrafficOverview,
     TrafficPath, TrafficSeriesBucket, TrafficStatusBreakdown,
@@ -65,10 +66,12 @@ pub fn routes() -> Router<Arc<AppState>> {
             "/api/app/{uuid}/traffic/breakdown/{dimension}",
             get(breakdown),
         )
+        .route("/api/app/{uuid}/traffic/series", get(app_series))
         // Server-wide variants: same shapes, merged across every app/host.
         .route("/api/traffic/overview", get(server_overview))
         .route("/api/traffic/paths", get(server_paths))
         .route("/api/traffic/breakdown/{dimension}", get(server_breakdown))
+        .route("/api/traffic/series", get(series))
         .route("/api/traffic/attribution", get(attribution))
 }
 
@@ -94,6 +97,12 @@ impl TopQuery {
             to: self.to.clone(),
         }
     }
+}
+
+/// The only knob for the series endpoints: `24h` (hourly) or `7d`/`30d` (daily).
+#[derive(Debug, Deserialize)]
+pub struct SeriesQuery {
+    pub range: Option<String>,
 }
 
 /// Floors `ts` to the start of its containing `width`-wide bucket. `div_euclid`
@@ -276,6 +285,77 @@ async fn attribution(State(state): State<Arc<AppState>>) -> Response {
         .unwrap_or_else(|e| e.into_inner())
         .clone();
     Json(TrafficAttribution { attribution }).into_response()
+}
+
+/// Server-wide status-class time series: per-bucket 2xx/3xx/4xx/5xx counts
+/// across every app/host, zero-filled to a fixed length by `range`.
+async fn series(State(state): State<Arc<AppState>>, Query(q): Query<SeriesQuery>) -> Response {
+    let Some(analytics) = state.analytics.clone() else {
+        return analytics_disabled();
+    };
+    let (width, count) = match resolve_series(q.range.as_deref()) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let now = now_ms();
+    let end = floor_to(now, width);
+    let from = end - (count as i64 - 1) * width;
+
+    let permit = match state.analytics_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let mut rows = Vec::new();
+        for (tier, lo, hi) in tier_reads_for(width, from, now) {
+            rows.extend(analytics.stats_rows_between(tier, lo, hi)?);
+        }
+        Ok::<_, store::StoreError>(aggregate_series(rows, now, width, count))
+    })
+    .await;
+    drop(permit);
+    match result {
+        Ok(Ok(out)) => Json(out).into_response(),
+        Ok(Err(e)) => internal_error(e),
+        Err(e) => internal_error(e),
+    }
+}
+
+/// Per-app variant of [`series`], filtered to one app via `stats_range`.
+async fn app_series(
+    Path(app): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<SeriesQuery>,
+) -> Response {
+    let Some(analytics) = state.analytics.clone() else {
+        return analytics_disabled();
+    };
+    let (width, count) = match resolve_series(q.range.as_deref()) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+    let now = now_ms();
+    let end = floor_to(now, width);
+    let from = end - (count as i64 - 1) * width;
+
+    let permit = match state.analytics_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        let mut rows = Vec::new();
+        for (tier, lo, hi) in tier_reads_for(width, from, now) {
+            rows.extend(analytics.stats_range(tier, &app, lo, hi)?);
+        }
+        Ok::<_, store::StoreError>(aggregate_series(rows, now, width, count))
+    })
+    .await;
+    drop(permit);
+    match result {
+        Ok(Ok(out)) => Json(out).into_response(),
+        Ok(Err(e)) => internal_error(e),
+        Err(e) => internal_error(e),
+    }
 }
 
 async fn overview(

--- a/crates/api/src/routes/traffic.rs
+++ b/crates/api/src/routes/traffic.rs
@@ -17,7 +17,7 @@ use crate::AppState;
 use crate::routes::cpu::{HistoryQuery, internal_error, resolve_range};
 use crate::types::{
     ErrorBody, TrafficAttribution, TrafficBreakdownEntry, TrafficLatency, TrafficOverview,
-    TrafficPath, TrafficStatusBreakdown,
+    TrafficPath, TrafficSeriesBucket, TrafficStatusBreakdown,
 };
 
 const MIN_MS: i64 = 60_000;
@@ -128,6 +128,85 @@ fn tier_reads(from: i64, to: i64) -> [(Tier, i64, i64); 3] {
         (Tier::H1, floor_to(from, HOUR_MS), to),
         (Tier::D1, floor_to(from, DAY_MS), to),
     ]
+}
+
+/// Maps the `range` query value to an output bucket width (ms) and a fixed
+/// output length. `24h` → 24 hourly buckets; `7d`/`30d` → 7/30 daily buckets.
+/// Empty or absent → `24h`. Anything else is a 400.
+#[allow(clippy::result_large_err)]
+fn resolve_series(range: Option<&str>) -> Result<(i64, usize), Response> {
+    match range.filter(|s| !s.is_empty()) {
+        None | Some("24h") => Ok((HOUR_MS, 24)),
+        Some("7d") => Ok((DAY_MS, 7)),
+        Some("30d") => Ok((DAY_MS, 30)),
+        Some(_) => Err(bad_range()),
+    }
+}
+
+fn bad_range() -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorBody {
+            error: "Invalid 'range'. Use one of: 24h, 7d, 30d".to_string(),
+        }),
+    )
+        .into_response()
+}
+
+/// Tiers to read for a series at the given output `width`. Only tiers at or
+/// finer than the output bucket are read, so every source bucket floors
+/// cleanly and completely into one output bucket:
+///   - hourly output (`HOUR_MS`): `M1` + `H1`. `D1` is skipped — nothing
+///     younger than 24h is ever compacted to the daily tier, so this loses no
+///     data and prevents a full day's counts landing in a single hour.
+///   - daily output (`DAY_MS`): `M1` + `H1` + `D1`; day is the coarsest tier,
+///     so no over-coarse rows can exist.
+fn tier_reads_for(width: i64, from: i64, to: i64) -> Vec<(Tier, i64, i64)> {
+    let all = tier_reads(from, to);
+    if width == HOUR_MS {
+        all[..2].to_vec()
+    } else {
+        all.to_vec()
+    }
+}
+
+/// Re-buckets per-bucket stats rows into a fixed-length, zero-filled series of
+/// `count` buckets, each `width` ms wide, ending at the bucket containing
+/// `now`. Rows outside that window are dropped. Pure — `now` is passed in so
+/// the aggregation is deterministic and testable.
+fn aggregate_series(
+    rows: Vec<StatsRow>,
+    now: i64,
+    width: i64,
+    count: usize,
+) -> Vec<TrafficSeriesBucket> {
+    let end = floor_to(now, width);
+    let first = end - (count as i64 - 1) * width;
+    let mut out: Vec<TrafficSeriesBucket> = (0..count)
+        .map(|i| TrafficSeriesBucket {
+            bucket: first + i as i64 * width,
+            s2xx: 0,
+            s3xx: 0,
+            s4xx: 0,
+            s5xx: 0,
+        })
+        .collect();
+
+    for r in &rows {
+        // `b` and `first` are both multiples of `width`, so the division is
+        // exact; a row before the window yields a negative index and is skipped.
+        let b = floor_to(r.bucket, width);
+        let idx = (b - first) / width;
+        if idx < 0 || idx as usize >= count {
+            continue;
+        }
+        let slot = &mut out[idx as usize];
+        slot.s2xx = slot.s2xx.saturating_add(r.s2xx);
+        slot.s3xx = slot.s3xx.saturating_add(r.s3xx);
+        slot.s4xx = slot.s4xx.saturating_add(r.s4xx);
+        slot.s5xx = slot.s5xx.saturating_add(r.s5xx);
+    }
+    out
 }
 
 #[allow(clippy::result_large_err)]

--- a/crates/api/src/routes/traffic/tests.rs
+++ b/crates/api/src/routes/traffic/tests.rs
@@ -817,3 +817,85 @@ async fn an_unbounded_range_sees_fresh_1m_data_immediately() {
         "1m (/a, /b) and 1d (/c) rows must all appear: {paths:?}"
     );
 }
+
+/// Minimal `StatsRow` with explicit status counts; sketch BLOBs are unused by
+/// `aggregate_series` so they are left empty.
+fn srow(bucket: i64, s2xx: i64, s3xx: i64, s4xx: i64, s5xx: i64) -> StatsRow {
+    StatsRow {
+        bucket,
+        app: "a".into(),
+        host: "h".into(),
+        requests: 0,
+        bytes_in: 0,
+        bytes_out: 0,
+        s2xx,
+        s3xx,
+        s4xx,
+        s5xx,
+        latency_tdigest: Vec::new(),
+        uniques_hll: Vec::new(),
+    }
+}
+
+/// `Response` is not `Debug`, so `Result::unwrap` won't compile; unwrap the Ok
+/// side by hand.
+fn ok_series(r: Result<(i64, usize), Response>) -> (i64, usize) {
+    match r {
+        Ok(v) => v,
+        Err(_) => panic!("expected Ok"),
+    }
+}
+
+#[test]
+fn resolve_series_maps_range_to_width_and_count() {
+    assert_eq!(ok_series(resolve_series(None)), (HOUR_MS, 24));
+    assert_eq!(ok_series(resolve_series(Some(""))), (HOUR_MS, 24));
+    assert_eq!(ok_series(resolve_series(Some("24h"))), (HOUR_MS, 24));
+    assert_eq!(ok_series(resolve_series(Some("7d"))), (DAY_MS, 7));
+    assert_eq!(ok_series(resolve_series(Some("30d"))), (DAY_MS, 30));
+    assert!(resolve_series(Some("bogus")).is_err());
+}
+
+#[test]
+fn tier_reads_for_excludes_daily_at_hourly_width() {
+    let hourly = tier_reads_for(HOUR_MS, 0, HOUR_MS);
+    assert_eq!(hourly.len(), 2);
+    assert_eq!(hourly[0].0, Tier::M1);
+    assert_eq!(hourly[1].0, Tier::H1);
+
+    let daily = tier_reads_for(DAY_MS, 0, DAY_MS);
+    assert_eq!(daily.len(), 3);
+    assert_eq!(daily[2].0, Tier::D1);
+}
+
+#[test]
+fn aggregate_series_zero_fills_sums_and_drops_out_of_range() {
+    let now = 5 * HOUR_MS + 1234; // mid-hour; end bucket = 5*HOUR
+    let rows = vec![
+        srow(4 * HOUR_MS + 30_000, 10, 1, 0, 0), // floors to 4*HOUR -> idx 1
+        srow(4 * HOUR_MS + 90_000, 5, 0, 2, 0),  // same hour bucket -> summed
+        srow(5 * HOUR_MS, 7, 0, 0, 3),           // idx 2
+        srow(2 * HOUR_MS, 99, 99, 99, 99),       // before window -> dropped
+    ];
+    let out = aggregate_series(rows, now, HOUR_MS, 3);
+
+    assert_eq!(out.len(), 3);
+    // Bucket 0 (3*HOUR) had no rows -> zero-filled.
+    assert_eq!(out[0].bucket, 3 * HOUR_MS);
+    assert_eq!(
+        (out[0].s2xx, out[0].s3xx, out[0].s4xx, out[0].s5xx),
+        (0, 0, 0, 0)
+    );
+    // Bucket 1 (4*HOUR) sums the two rows in that hour.
+    assert_eq!(out[1].bucket, 4 * HOUR_MS);
+    assert_eq!(
+        (out[1].s2xx, out[1].s3xx, out[1].s4xx, out[1].s5xx),
+        (15, 1, 2, 0)
+    );
+    // Bucket 2 (5*HOUR).
+    assert_eq!(out[2].bucket, 5 * HOUR_MS);
+    assert_eq!(
+        (out[2].s2xx, out[2].s3xx, out[2].s4xx, out[2].s5xx),
+        (7, 0, 0, 3)
+    );
+}

--- a/crates/api/src/routes/traffic/tests.rs
+++ b/crates/api/src/routes/traffic/tests.rs
@@ -899,3 +899,46 @@ fn aggregate_series_zero_fills_sums_and_drops_out_of_range() {
         (7, 0, 0, 3)
     );
 }
+
+#[tokio::test]
+async fn server_series_is_fixed_length_and_zero_filled() {
+    // Seeded data sits in 2023, far outside any window ending "now", so counts
+    // are zero — but the array is always full length.
+    let (status, body) = get("/api/traffic/series?range=7d").await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = body.as_array().expect("array body");
+    assert_eq!(arr.len(), 7);
+    for b in arr {
+        assert!(b["bucket"].is_i64());
+        assert_eq!(b["s2xx"], 0);
+        assert_eq!(b["s3xx"], 0);
+        assert_eq!(b["s4xx"], 0);
+        assert_eq!(b["s5xx"], 0);
+    }
+}
+
+#[tokio::test]
+async fn server_series_defaults_to_24_hourly_buckets() {
+    let (status, body) = get("/api/traffic/series").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.as_array().expect("array body").len(), 24);
+}
+
+#[tokio::test]
+async fn app_series_is_fixed_length() {
+    let (status, body) = get("/api/app/app-a/traffic/series?range=30d").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body.as_array().expect("array body").len(), 30);
+}
+
+#[tokio::test]
+async fn series_rejects_unknown_range() {
+    let (status, _) = get("/api/traffic/series?range=bogus").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn series_404_when_analytics_disabled() {
+    let (status, _) = get_with(state(None), "/api/traffic/series").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/crates/api/src/time.rs
+++ b/crates/api/src/time.rs
@@ -29,3 +29,8 @@ pub fn format_millis(ms: i64) -> String {
 pub fn now_layout() -> String {
     OffsetDateTime::now_utc().format(LAYOUT).unwrap_or_default()
 }
+
+/// The current time as unix milliseconds UTC, for bucket-aligning a series.
+pub fn now_ms() -> i64 {
+    (OffsetDateTime::now_utc().unix_timestamp_nanos() / 1_000_000) as i64
+}

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -118,6 +118,18 @@ pub struct TrafficBreakdownEntry {
     pub bytes_out: i64,
 }
 
+/// One time bucket of status-class request counts, for the series endpoints.
+/// `bucket` is the unix-millis start of the bucket (hour- or day-aligned by
+/// the request's `range`). Counts are zero for buckets with no traffic.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrafficSeriesBucket {
+    pub bucket: i64,
+    pub s2xx: i64,
+    pub s3xx: i64,
+    pub s4xx: i64,
+    pub s5xx: i64,
+}
+
 /// The attribution string required by the license of whichever GeoIP source
 /// is currently active (design spec §6), or `null` when none applies (GeoIP
 /// disabled, not yet resolved, or an unrecognized `GEOIP_DB_URL` override).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -468,6 +468,36 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/app/{uuid}/traffic/series:
+    get:
+      summary: Get app status-class time series
+      description: |
+        Per-bucket 2xx/3xx/4xx/5xx request counts for one app, zero-filled to
+        a fixed length: 24 hourly buckets for `range=24h`, 7 or 30 daily
+        buckets for `range=7d`/`range=30d`.
+      tags:
+        - Traffic Analytics
+      parameters:
+        - $ref: '#/components/parameters/AppUuid'
+        - $ref: '#/components/parameters/Range'
+      responses:
+        '200':
+          description: Status-class time series for the app
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrafficSeriesBucket'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/TrafficNotEnabledError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/traffic/overview:
     get:
       summary: Get server-wide traffic overview
@@ -593,6 +623,34 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/traffic/series:
+    get:
+      summary: Get server-wide status-class time series
+      description: |
+        Per-bucket 2xx/3xx/4xx/5xx request counts across every app/host,
+        zero-filled to a fixed length (see the per-app variant for granularity).
+      tags:
+        - Traffic Analytics
+      parameters:
+        - $ref: '#/components/parameters/Range'
+      responses:
+        '200':
+          description: Status-class time series
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/TrafficSeriesBucket'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/TrafficNotEnabledError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/stats:
     get:
       summary: Get database statistics
@@ -671,6 +729,19 @@ components:
         maximum: 1000
         default: 50
       example: 20
+
+    Range:
+      name: range
+      in: query
+      description: |
+        Time window and bucket granularity for a series. `24h` yields 24
+        hourly buckets; `7d`/`30d` yield 7/30 daily buckets. Defaults to `24h`.
+      required: false
+      schema:
+        type: string
+        enum: [24h, 7d, 30d]
+        default: 24h
+      example: 7d
 
   schemas:
     CurrentCPUUsage:
@@ -908,6 +979,35 @@ components:
           type: integer
           format: int64
           example: 40
+
+    TrafficSeriesBucket:
+      type: object
+      description: |
+        One time bucket of status-class request counts. `bucket` is the
+        unix-millis start of the bucket (hour- or day-aligned per `range`);
+        counts are zero for buckets with no traffic.
+      properties:
+        bucket:
+          type: integer
+          format: int64
+          description: Unix-millis start of the bucket
+          example: 1723334400000
+        s2xx:
+          type: integer
+          format: int64
+          example: 42
+        s3xx:
+          type: integer
+          format: int64
+          example: 3
+        s4xx:
+          type: integer
+          format: int64
+          example: 1
+        s5xx:
+          type: integer
+          format: int64
+          example: 0
 
     TrafficLatency:
       type: object


### PR DESCRIPTION
## Summary
- Add `GET /api/traffic/series` and `GET /api/app/:uuid/traffic/series`, returning fixed-length, zero-filled status-class (2xx/3xx/4xx/5xx) request counts per bucket for charting
- Support `range=24h` (24 hourly buckets, default), `range=7d` (7 daily buckets), and `range=30d` (30 daily buckets); invalid values return `400`
- Apps/hosts with no traffic in range return `200` with every bucket zeroed rather than `404`
- Document both endpoints and the new `TrafficSeriesBucket` schema in `API.md` and `openapi.yaml`
