### PR TITLE
feat(traffic): detect bot/AI-agent UAs and attribute paths per-app

### DIFF
--- a/API.md
+++ b/API.md
@@ -654,7 +654,7 @@ Busiest request paths across **every app** on the box, summed over the range wit
 |-----------|------|----------|---------|-------------|
 | `from` | string | No | `1970-01-01T00:00:00Z` | Start date in ISO 8601 format |
 | `to` | string | No | Current time | End date in ISO 8601 format |
-| `limit` | integer | No | `50` | Number of paths to return (max `1000`), applied after summing across apps and buckets |
+| `limit` | integer | No | `50` | Number of paths to return (max `1000`), applied after summing each `(app, path)` pair across buckets |
 
 Response body is identical to the per-app top-paths endpoint.
 

--- a/API.md
+++ b/API.md
@@ -554,6 +554,7 @@ Retrieve the busiest request paths for one app, summed across every bucket in ra
 [
   {
     "path": "/api/checkout",
+    "app": "jc4wsgs",
     "requests": 5210,
     "bytes_out": 41200000,
     "p50": 38.0,
@@ -564,6 +565,7 @@ Retrieve the busiest request paths for one app, summed across every bucket in ra
 
 **Fields:**
 - `path` (string): Request path. A synthetic `__other__` entry absorbs the long tail past the server's top-N cap (`TRAFFIC_TOPN`)
+- `app` (string): The app (Coolify app UUID, or host for Caddy) that served this path. On this per-app endpoint it is always the queried app; on the server-wide endpoint it attributes each path back to its owning app
 - `requests` (number): Total request count for this path in range
 - `bytes_out` (number): Total response bytes for this path in range
 - `p50` / `p95` (number): Approximate per-path latency percentiles in milliseconds (`p99` is available from the overview endpoint)
@@ -578,7 +580,7 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 
 ### Get App Dimension Breakdown
 
-Retrieve the top values of one dimension (status, method, country, referer, browser, OS, device, protocol, scheme, TLS version, cache status, or bot classification) for one app, summed across every bucket in range.
+Retrieve the top values of one dimension (status, method, country, referer, browser, OS, device, protocol, scheme, TLS version, cache status, bot classification, bot/AI-agent name, resolved client IP, or raw User-Agent) for one app, summed across every bucket in range.
 
 **Endpoint:** `GET /api/app/:uuid/traffic/breakdown/:dimension`
 
@@ -586,7 +588,7 @@ Retrieve the top values of one dimension (status, method, country, referer, brow
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `uuid` | string | Yes | Coolify app UUID (or host, for Caddy) |
-| `dimension` | string | Yes | One of `status`, `method`, `country`, `referer`, `browser`, `os`, `device`, `protocol`, `scheme`, `tls`, `cache`, `bot`. An unrecognized dimension returns an empty array, not an error |
+| `dimension` | string | Yes | One of `status`, `method`, `country`, `referer`, `browser`, `os`, `device`, `protocol`, `scheme`, `tls`, `cache`, `bot`, `agent`, `ip`, `useragent`. `agent` holds the bot/AI-agent name (e.g. `GPTBot`, `ClaudeBot`) and is only present for bot traffic. `ip` holds the resolved real client IP (respecting Cloudflare `CF-Connecting-IP` and `X-Forwarded-For`); `useragent` holds the raw `User-Agent` header. An unrecognized dimension returns an empty array, not an error |
 
 **Query Parameters:**
 | Parameter | Type | Required | Default | Description |
@@ -643,7 +645,7 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 
 ### Get Server-Wide Top Paths
 
-Busiest request paths across **every app** on the box, summed over the range with per-path latency. The same path served by multiple apps is merged into a single entry, giving a correct top-N across all apps rather than a merge of per-app top-N lists.
+Busiest request paths across **every app** on the box, summed over the range with per-path latency. Rows are keyed by `(app, path)`, so the same path served by multiple apps stays a separate entry per app — each labelled with its owning `app` — giving a correct top-N across all apps that preserves per-app attribution rather than merging distinct apps' paths together.
 
 **Endpoint:** `GET /api/traffic/paths`
 
@@ -673,7 +675,7 @@ Top values of one dimension across **every app** on the box, summed over the ran
 **Path Parameters:**
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `dimension` | string | Yes | One of `status`, `method`, `country`, `referer`, `browser`, `os`, `device`, `protocol`, `scheme`, `tls`, `cache`, `bot`. An unrecognized dimension returns an empty array, not an error |
+| `dimension` | string | Yes | One of `status`, `method`, `country`, `referer`, `browser`, `os`, `device`, `protocol`, `scheme`, `tls`, `cache`, `bot`, `agent`, `ip`, `useragent`. `agent` holds the bot/AI-agent name (e.g. `GPTBot`, `ClaudeBot`) and is only present for bot traffic. `ip` holds the resolved real client IP (respecting Cloudflare `CF-Connecting-IP` and `X-Forwarded-For`); `useragent` holds the raw `User-Agent` header. An unrecognized dimension returns an empty array, not an error |
 
 **Query Parameters:**
 | Parameter | Type | Required | Default | Description |

--- a/crates/api/src/routes/traffic.rs
+++ b/crates/api/src/routes/traffic.rs
@@ -504,9 +504,10 @@ async fn server_overview(
     }
 }
 
-/// Server-wide top paths: [`paths`] across every app. `top_paths` groups by path
-/// string, so the same path served by different apps (e.g. `/`) merges into one
-/// server-wide row — a correct top-N over all apps, not a merge of per-app lists.
+/// Server-wide top paths: [`paths`] across every app. `top_paths` groups by
+/// `(app, path)`, so the same path served by different apps (e.g. `/`) stays a
+/// separate row per app, each carrying its owning app — a correct top-N over
+/// all apps that preserves per-app attribution, not a merge of per-app lists.
 async fn server_paths(State(state): State<Arc<AppState>>, Query(q): Query<TopQuery>) -> Response {
     let Some(analytics) = state.analytics.clone() else {
         return analytics_disabled();
@@ -651,8 +652,14 @@ fn summarize_stats(rows: Vec<StatsRow>) -> TrafficOverview {
     }
 }
 
-/// Groups per-bucket path rows by path, summing counters and merging each
-/// path's latency digests, then returns the `limit` busiest paths.
+/// Groups per-bucket path rows by `(app, path)`, summing counters and merging
+/// each group's latency digests, then returns the `limit` busiest paths.
+///
+/// Keying by `(app, path)` rather than `path` alone keeps per-app attribution
+/// on the server-wide endpoint: the same path (e.g. `/`) served by two apps
+/// stays two rows, each labelled with its owning app, instead of collapsing
+/// into one. The per-app endpoint is unaffected — every row shares one app, so
+/// the tuple degenerates to grouping by path.
 ///
 /// Digests are folded *incrementally*, one row at a time, so resident sketch
 /// memory is bounded by the number of distinct paths rather than by (path,
@@ -666,13 +673,15 @@ fn top_paths(rows: Vec<PathRow>, limit: usize) -> Vec<TrafficPath> {
         latency: LatencyDigest,
     }
 
-    let mut by_path: HashMap<String, Acc> = HashMap::new();
+    let mut by_path: HashMap<(String, String), Acc> = HashMap::new();
     for r in rows {
-        let acc = by_path.entry(r.path).or_insert_with(|| Acc {
-            requests: 0,
-            bytes_out: 0,
-            latency: LatencyDigest::new(),
-        });
+        let acc = by_path
+            .entry((r.app.clone(), r.path))
+            .or_insert_with(|| Acc {
+                requests: 0,
+                bytes_out: 0,
+                latency: LatencyDigest::new(),
+            });
         acc.requests = acc.requests.saturating_add(r.requests);
         acc.bytes_out = acc.bytes_out.saturating_add(r.bytes_out);
         match LatencyDigest::from_bytes(&r.latency_tdigest) {
@@ -691,15 +700,18 @@ fn top_paths(rows: Vec<PathRow>, limit: usize) -> Vec<TrafficPath> {
 
     let mut out: Vec<TrafficPath> = by_path
         .into_iter()
-        .map(|(path, acc)| TrafficPath {
+        .map(|((app, path), acc)| TrafficPath {
             path,
+            app,
             requests: acc.requests,
             bytes_out: acc.bytes_out,
             p50: acc.latency.quantile(0.5),
             p95: acc.latency.quantile(0.95),
         })
         .collect();
-    sort_and_truncate(&mut out, limit, |p| (p.requests, &p.path));
+    sort_and_truncate(&mut out, limit, |p| {
+        (p.requests, (p.app.clone(), p.path.clone()))
+    });
     out
 }
 
@@ -721,21 +733,25 @@ fn top_breakdown(rows: Vec<BreakdownRow>, limit: usize) -> Vec<TrafficBreakdownE
             bytes_out,
         })
         .collect();
-    sort_and_truncate(&mut out, limit, |e| (e.requests, &e.value));
+    sort_and_truncate(&mut out, limit, |e| (e.requests, e.value.clone()));
     out
 }
 
 /// Sorts by request count descending, breaking ties on the key ascending so
 /// the response is deterministic (the `HashMap` grouping above is not), then
-/// keeps the top `limit`.
-fn sort_and_truncate<T, F>(rows: &mut Vec<T>, limit: usize, key: F)
+/// keeps the top `limit`. The tie-break key is generic so paths can break ties
+/// on `(app, path)` while breakdowns break on the single `value`.
+fn sort_and_truncate<T, K, F>(rows: &mut Vec<T>, limit: usize, key: F)
 where
-    F: Fn(&T) -> (i64, &String),
+    K: Ord,
+    F: Fn(&T) -> (i64, K),
 {
-    rows.sort_by(|a, b| {
-        let (a_reqs, a_key) = key(a);
-        let (b_reqs, b_key) = key(b);
-        b_reqs.cmp(&a_reqs).then_with(|| a_key.cmp(b_key))
+    // `Reverse` on the request count sorts it descending while the owned
+    // tie-break key stays ascending. `sort_by_cached_key` computes each row's
+    // key once, so the per-row key allocation is O(rows), not O(rows log rows).
+    rows.sort_by_cached_key(|t| {
+        let (reqs, k) = key(t);
+        (std::cmp::Reverse(reqs), k)
     });
     rows.truncate(limit);
 }

--- a/crates/api/src/routes/traffic/tests.rs
+++ b/crates/api/src/routes/traffic/tests.rs
@@ -405,9 +405,11 @@ async fn paths_sum_across_buckets_and_sort_by_requests() {
     let rows = j.as_array().unwrap();
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["path"], "/b", "22 requests must outrank /a's 8");
+    assert_eq!(rows[0]["app"], "app-a", "every row carries its owning app");
     assert_eq!(rows[0]["requests"], 22);
     assert_eq!(rows[0]["bytes_out"], 2200);
     assert_eq!(rows[1]["path"], "/a");
+    assert_eq!(rows[1]["app"], "app-a");
     assert_eq!(rows[1]["requests"], 8);
     assert!(rows[0]["p50"].as_f64().unwrap() > 0.0);
     assert!(rows[0]["p95"].as_f64().unwrap() > 0.0);
@@ -478,17 +480,31 @@ async fn server_overview_merges_across_all_apps() {
 }
 
 #[tokio::test]
-async fn server_paths_merge_the_same_path_across_apps() {
+async fn server_paths_keep_apps_separate_with_per_app_attribution() {
+    // `/a` is served by both app-a (8) and app-b (4). Keyed by (app, path),
+    // the server-wide endpoint must return two distinct `/a` rows — one per
+    // app — instead of merging them into a single 12-request row, so a UI can
+    // map each path back to its owning app.
     let (s, j) = get(&format!("/api/traffic/paths?{RANGE}")).await;
     assert_eq!(s, StatusCode::OK);
     let rows = j.as_array().unwrap();
-    assert_eq!(rows.len(), 2);
+    assert_eq!(rows.len(), 3, "/a is not merged across apps");
+
     assert_eq!(rows[0]["path"], "/b", "app-a's 22 still leads");
+    assert_eq!(rows[0]["app"], "app-a");
     assert_eq!(rows[0]["requests"], 22);
+
+    // Both `/a` rows follow; requests desc then the (app, path) tie-break puts
+    // app-a's 8 ahead of app-b's 4.
     assert_eq!(rows[1]["path"], "/a");
+    assert_eq!(rows[1]["app"], "app-a");
+    assert_eq!(rows[1]["requests"], 8);
+
+    assert_eq!(rows[2]["path"], "/a");
+    assert_eq!(rows[2]["app"], "app-b");
     assert_eq!(
-        rows[1]["requests"], 12,
-        "/a is app-a's 8 + app-b's 4 merged across apps"
+        rows[2]["requests"], 4,
+        "app-b's /a stays its own row, attributed to app-b"
     );
 }
 

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -103,6 +103,10 @@ pub struct TrafficLatency {
 #[derive(Debug, Clone, Serialize)]
 pub struct TrafficPath {
     pub path: String,
+    /// The app (Coolify app UUID, or host for Caddy) that served this path,
+    /// so a server-wide response can attribute each path back to its owning
+    /// app/domain. On a per-app endpoint every row carries the queried app.
+    pub app: String,
     pub requests: i64,
     pub bytes_out: i64,
     pub p50: f64,

--- a/crates/traffic/src/aggregator.rs
+++ b/crates/traffic/src/aggregator.rs
@@ -83,8 +83,8 @@ impl Aggregator {
     /// Folds one already-enriched event into the current window.
     ///
     /// Every optional enrichment/event field (country, referer, tls,
-    /// cache, browser/os/device, client_ip) is skipped cleanly when
-    /// absent/empty rather than guessed at, matching the project's
+    /// cache, browser/os/device, client_ip, user_agent) is skipped cleanly
+    /// when absent/empty rather than guessed at, matching the project's
     /// "skip incomplete data" convention.
     pub fn record(&mut self, ev: &RequestEvent, en: &Enriched) {
         let app = ev.app.to_string();
@@ -153,6 +153,35 @@ impl Aggregator {
         }
         let bot = if en.bot { "true" } else { "false" };
         record_breakdown(dims, "bot", bot, bytes, topn, false);
+
+        // `agent` — the bot's / AI-agent's name, recorded only for bot traffic.
+        // Value precedence: Cloudflare's verified-bot name, else the
+        // known-agent detector, else woothee's crawler name (`browser` when
+        // `is_bot`). `skip_empty=true` drops non-bot traffic, where all three
+        // resolve to empty, so this dimension only ever holds bots.
+        let agent = ev
+            .cf_verified_bot
+            .as_deref()
+            .filter(|name| !name.is_empty())
+            .or(en.agent_name.as_deref())
+            .or_else(|| en.ua.is_bot.then_some(en.ua.browser.as_str()))
+            .unwrap_or("");
+        record_breakdown(dims, "agent", agent, bytes, topn, true);
+
+        // `ip` — the resolved *real* client IP. `en.client_ip` is already
+        // CF/XFF-resolved in `enrich` (CF-Connecting-IP → first X-Forwarded-For
+        // entry → raw connection IP), so this dimension naturally holds the real
+        // visitor behind Cloudflare / a reverse proxy, not the proxy's own IP.
+        // Rendered into a local binding so the borrow outlives the call.
+        // `skip_empty=true` drops requests with no resolvable IP.
+        let ip = en.client_ip.map(|ip| ip.to_string()).unwrap_or_default();
+        record_breakdown(dims, "ip", &ip, bytes, topn, true);
+
+        // `useragent` — the raw User-Agent header, recorded verbatim (never
+        // lowercased or normalized) so the UI can show the full agent string.
+        // `skip_empty=true` drops requests without a User-Agent.
+        let user_agent = ev.user_agent.as_deref().unwrap_or("");
+        record_breakdown(dims, "useragent", user_agent, bytes, topn, true);
     }
 
     /// Drains the current window into row types for `bucket`, capping
@@ -249,11 +278,11 @@ impl Aggregator {
 /// Adds one value to a dimension's top-N within an app's [`DimMap`]. With
 /// `skip_empty`, an empty
 /// `value` (a woothee UA-parse fallback, or an absent event field) is dropped
-/// rather than recorded — used by the seven optional dimensions (`country`,
-/// `referer`, `browser`, `os`, `device`, `tls`, `cache`). The five
-/// always-recorded dimensions (`status`, `method`, `protocol`, `scheme`,
-/// `bot`), drawn from required fields, pass `skip_empty=false` so an empty
-/// value is never silently dropped.
+/// rather than recorded — used by the ten optional dimensions (`country`,
+/// `referer`, `browser`, `os`, `device`, `tls`, `cache`, `agent`, `ip`,
+/// `useragent`). The five always-recorded dimensions (`status`, `method`,
+/// `protocol`, `scheme`, `bot`), drawn from required fields, pass
+/// `skip_empty=false` so an empty value is never silently dropped.
 fn record_breakdown(
     dims: &mut DimMap,
     dim: &'static str,

--- a/crates/traffic/src/aggregator/tests.rs
+++ b/crates/traffic/src/aggregator/tests.rs
@@ -34,6 +34,7 @@ fn base_enriched() -> Enriched {
         client_ip: None,
         cache: None,
         bot: false,
+        agent_name: None,
     }
 }
 
@@ -195,6 +196,123 @@ fn take_rollup_clears_state_for_next_window() {
     let third = a.take_rollup(180_000);
     assert_eq!(third.stats.len(), 1);
     assert_eq!(third.stats[0].requests, 1);
+}
+
+#[test]
+fn agent_dimension_records_a_known_ai_agent() {
+    let mut a = Aggregator::new(50);
+    let ev = base_event();
+    let mut en = base_enriched();
+    // A known AI agent, as the enricher's known-agent detector would resolve.
+    en.agent_name = Some("GPTBot".to_string());
+    en.bot = true;
+
+    a.record(&ev, &en);
+
+    let rollup = a.take_rollup(60_000);
+    let agent_rows: Vec<_> = rollup
+        .breakdown
+        .iter()
+        .filter(|r| r.dimension == "agent")
+        .collect();
+    assert_eq!(agent_rows.len(), 1, "one agent row for the bot request");
+    assert_eq!(agent_rows[0].value, "GPTBot");
+    assert_eq!(agent_rows[0].requests, 1);
+}
+
+#[test]
+fn agent_dimension_is_absent_for_normal_browser_traffic() {
+    let mut a = Aggregator::new(50);
+    let ev = base_event();
+    // base_enriched(): bot=false, agent_name=None, ua.is_bot=false — all three
+    // agent sources resolve to empty, so `skip_empty` records nothing.
+    let en = base_enriched();
+
+    a.record(&ev, &en);
+
+    let rollup = a.take_rollup(60_000);
+    assert!(
+        rollup.breakdown.iter().all(|r| r.dimension != "agent"),
+        "non-bot traffic must not produce an agent breakdown row"
+    );
+}
+
+#[test]
+fn ip_dimension_records_the_resolved_client_ip() {
+    let mut a = Aggregator::new(50);
+    let ev = base_event();
+    let mut en = base_enriched();
+    // `client_ip` is already CF/XFF-resolved in enrich; the aggregator just
+    // renders it into an `ip` breakdown value.
+    en.client_ip = Some("203.0.113.7".parse::<IpAddr>().unwrap());
+
+    a.record(&ev, &en);
+
+    let rollup = a.take_rollup(60_000);
+    let ip_rows: Vec<_> = rollup
+        .breakdown
+        .iter()
+        .filter(|r| r.dimension == "ip")
+        .collect();
+    assert_eq!(ip_rows.len(), 1, "one ip row for the resolvable request");
+    assert_eq!(ip_rows[0].value, "203.0.113.7");
+    assert_eq!(ip_rows[0].requests, 1);
+}
+
+#[test]
+fn ip_dimension_is_absent_when_client_ip_unresolved() {
+    let mut a = Aggregator::new(50);
+    let ev = base_event();
+    // base_enriched(): client_ip = None — skip_empty drops the row.
+    let en = base_enriched();
+
+    a.record(&ev, &en);
+
+    let rollup = a.take_rollup(60_000);
+    assert!(
+        rollup.breakdown.iter().all(|r| r.dimension != "ip"),
+        "a request with no resolvable client IP must not produce an ip row"
+    );
+}
+
+#[test]
+fn useragent_dimension_records_the_raw_user_agent() {
+    let mut a = Aggregator::new(50);
+    let mut ev = base_event();
+    let ua = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36";
+    ev.user_agent = Some(ua.into());
+    let en = base_enriched();
+
+    a.record(&ev, &en);
+
+    let rollup = a.take_rollup(60_000);
+    let ua_rows: Vec<_> = rollup
+        .breakdown
+        .iter()
+        .filter(|r| r.dimension == "useragent")
+        .collect();
+    assert_eq!(ua_rows.len(), 1, "one useragent row for the request");
+    assert_eq!(
+        ua_rows[0].value, ua,
+        "the raw User-Agent must be recorded verbatim, not normalized"
+    );
+    assert_eq!(ua_rows[0].requests, 1);
+}
+
+#[test]
+fn useragent_dimension_is_absent_when_header_missing() {
+    let mut a = Aggregator::new(50);
+    // base_event(): user_agent = None — skip_empty drops the row.
+    let ev = base_event();
+    let en = base_enriched();
+
+    a.record(&ev, &en);
+
+    let rollup = a.take_rollup(60_000);
+    assert!(
+        rollup.breakdown.iter().all(|r| r.dimension != "useragent"),
+        "a request with no User-Agent must not produce a useragent row"
+    );
 }
 
 #[test]

--- a/crates/traffic/src/enrich.rs
+++ b/crates/traffic/src/enrich.rs
@@ -77,9 +77,11 @@ static KNOWN_AGENTS: &[(&str, &str)] = &[
     ("perplexitybot", "PerplexityBot"),
     // Mistral
     ("mistralai-user", "MistralAI-User"),
-    // xAI
+    // xAI. No bare "grok" token: xAI's documented crawlers rarely send an
+    // identifiable UA in practice (they largely spoof browser UAs instead),
+    // and a bare substring match would false-positive on unrelated products
+    // whose name merely contains "grok" (e.g. Logstash's Grok filters).
     ("grokbot", "GrokBot"),
-    ("grok", "Grok"),
     // DeepSeek
     ("deepseekbot", "DeepSeekBot"),
     // Amazon

--- a/crates/traffic/src/enrich.rs
+++ b/crates/traffic/src/enrich.rs
@@ -42,29 +42,80 @@ pub struct UaInfo {
 /// Well-known bot / AI-agent User-Agent tokens and their canonical display
 /// names, matched case-insensitively as a substring of the raw User-Agent.
 /// This catches AI crawlers even when Cloudflare's verified-bot header is
-/// absent (self-hosted, non-CF deployments). Ordered most-specific first so a
-/// vendor's specific product token (`Google-Extended`) is preferred over its
-/// generic crawler (`Googlebot`) when both could match; the first hit wins.
+/// absent (self-hosted, non-CF deployments), or when Cloudflare hasn't
+/// verified a given crawler yet.
+///
+/// Grouped by operator; within a group, a token that is itself a substring of
+/// another token in the same group (e.g. `applebot` inside
+/// `applebot-extended`) is listed *after* the longer, more specific token so
+/// the specific one wins — the first hit in list order wins overall.
+/// Sourced from each operator's own crawler docs plus the community-maintained
+/// <https://github.com/ai-robots-txt/ai.robots.txt> registry.
 static KNOWN_AGENTS: &[(&str, &str)] = &[
+    // OpenAI
     ("gptbot", "GPTBot"),
-    ("chatgpt-user", "ChatGPT-User"),
     ("oai-searchbot", "OAI-SearchBot"),
-    ("claudebot", "ClaudeBot"),
+    ("chatgpt-operator", "ChatGPT-Operator"),
+    ("chatgpt-user", "ChatGPT-User"),
+    // Anthropic
+    ("claude-code", "Claude-Code"),
+    ("claude-searchbot", "Claude-SearchBot"),
+    ("claude-user", "Claude-User"),
     ("claude-web", "Claude-Web"),
+    ("claudebot", "ClaudeBot"),
     ("anthropic-ai", "anthropic-ai"),
-    ("perplexitybot", "PerplexityBot"),
+    // Google
     ("google-extended", "Google-Extended"),
+    ("googleother", "GoogleOther"),
     ("googlebot", "Googlebot"),
-    ("bingbot", "Bingbot"),
-    ("bytespider", "Bytespider"),
-    ("ccbot", "CCBot"),
-    ("amazonbot", "Amazonbot"),
-    ("applebot", "Applebot"),
+    // Meta
     ("meta-externalagent", "Meta-ExternalAgent"),
-    ("facebookexternalhit", "Meta-ExternalAgent"),
+    ("meta-externalfetcher", "Meta-ExternalFetcher"),
+    ("facebookexternalhit", "facebookexternalhit"),
+    // Perplexity
+    ("perplexity-user", "Perplexity-User"),
+    ("perplexitybot", "PerplexityBot"),
+    // Mistral
+    ("mistralai-user", "MistralAI-User"),
+    // xAI
+    ("grokbot", "GrokBot"),
+    ("grok", "Grok"),
+    // DeepSeek
+    ("deepseekbot", "DeepSeekBot"),
+    // Amazon
+    ("amazonbot", "Amazonbot"),
+    // Apple
+    ("applebot-extended", "Applebot-Extended"),
+    ("applebot", "Applebot"),
+    // ByteDance
+    ("bytespider", "Bytespider"),
+    ("tiktokspider", "TikTokSpider"),
+    // Common Crawl (training data used by many labs)
+    ("ccbot", "CCBot"),
+    // Cohere
+    (
+        "cohere-training-data-crawler",
+        "cohere-training-data-crawler",
+    ),
     ("cohere-ai", "cohere-ai"),
+    // Allen Institute for AI
+    ("ai2bot-dolma", "Ai2Bot-Dolma"),
+    ("ai2bot", "AI2Bot"),
+    // Other AI-specific crawlers
+    ("bigsur.ai", "bigsur.ai"),
+    ("digitaloceangenai-crawler", "DigitalOceanGenAI-Crawler"),
+    ("linerbot", "LinerBot"),
+    ("mycentralaiscraperbot", "MyCentralAIScraperBot"),
+    ("pangubot", "PanguBot"),
+    ("sbintuitionsbot", "SBIntuitionsBot"),
+    ("youbot", "YouBot"),
     ("diffbot", "Diffbot"),
+    ("img2dataset", "img2dataset"),
+    ("quillbot", "QuillBot"),
+    // Search engines with an AI-assist crawler
+    ("duckassistbot", "DuckAssistBot"),
     ("duckduckbot", "DuckDuckBot"),
+    ("bingbot", "Bingbot"),
     ("yandexbot", "YandexBot"),
 ];
 

--- a/crates/traffic/src/enrich.rs
+++ b/crates/traffic/src/enrich.rs
@@ -39,6 +39,45 @@ pub struct UaInfo {
     pub is_bot: bool,
 }
 
+/// Well-known bot / AI-agent User-Agent tokens and their canonical display
+/// names, matched case-insensitively as a substring of the raw User-Agent.
+/// This catches AI crawlers even when Cloudflare's verified-bot header is
+/// absent (self-hosted, non-CF deployments). Ordered most-specific first so a
+/// vendor's specific product token (`Google-Extended`) is preferred over its
+/// generic crawler (`Googlebot`) when both could match; the first hit wins.
+static KNOWN_AGENTS: &[(&str, &str)] = &[
+    ("gptbot", "GPTBot"),
+    ("chatgpt-user", "ChatGPT-User"),
+    ("oai-searchbot", "OAI-SearchBot"),
+    ("claudebot", "ClaudeBot"),
+    ("claude-web", "Claude-Web"),
+    ("anthropic-ai", "anthropic-ai"),
+    ("perplexitybot", "PerplexityBot"),
+    ("google-extended", "Google-Extended"),
+    ("googlebot", "Googlebot"),
+    ("bingbot", "Bingbot"),
+    ("bytespider", "Bytespider"),
+    ("ccbot", "CCBot"),
+    ("amazonbot", "Amazonbot"),
+    ("applebot", "Applebot"),
+    ("meta-externalagent", "Meta-ExternalAgent"),
+    ("facebookexternalhit", "Meta-ExternalAgent"),
+    ("cohere-ai", "cohere-ai"),
+    ("diffbot", "Diffbot"),
+    ("duckduckbot", "DuckDuckBot"),
+    ("yandexbot", "YandexBot"),
+];
+
+/// Returns the canonical name of the first [`KNOWN_AGENTS`] token found as a
+/// case-insensitive substring of `ua`, or `None` when no known agent matches.
+fn detect_known_agent(ua: &str) -> Option<&'static str> {
+    let lower = ua.to_ascii_lowercase();
+    KNOWN_AGENTS
+        .iter()
+        .find(|(token, _)| lower.contains(token))
+        .map(|(_, name)| *name)
+}
+
 /// Result of enriching a `RequestEvent`.
 pub struct Enriched {
     /// Resolved country code, if any.
@@ -51,6 +90,10 @@ pub struct Enriched {
     pub cache: Option<String>,
     /// Whether the request is attributed to a bot.
     pub bot: bool,
+    /// Canonical name of a recognized bot / AI-agent (e.g. "GPTBot",
+    /// "ClaudeBot"), from the [`KNOWN_AGENTS`] substring match, or `None`.
+    /// A match here also forces [`Self::bot`] true.
+    pub agent_name: Option<String>,
 }
 
 /// Enriches `RequestEvent`s with geolocation, UA parsing, and CF-header precedence.
@@ -95,7 +138,17 @@ impl Enricher {
             None => UaInfo::default(),
         };
 
-        let bot = ev.cf_verified_bot.is_some() || ua.is_bot;
+        // A known-agent substring match is derived from the *raw* UA, not
+        // woothee's parse, so AI crawlers are caught even where woothee has no
+        // rule for them. A match implies bot traffic, OR'd into the existing
+        // detection so neither signal can regress the other.
+        let agent_name = ev
+            .user_agent
+            .as_deref()
+            .and_then(detect_known_agent)
+            .map(String::from);
+
+        let bot = ev.cf_verified_bot.is_some() || ua.is_bot || agent_name.is_some();
 
         let cache = ev.cf_cache_status.as_deref().map(String::from);
 
@@ -105,6 +158,7 @@ impl Enricher {
             client_ip,
             cache,
             bot,
+            agent_name,
         }
     }
 

--- a/crates/traffic/src/enrich/tests.rs
+++ b/crates/traffic/src/enrich/tests.rs
@@ -123,6 +123,70 @@ fn known_agent_detected_from_ua_substring() {
 }
 
 #[test]
+fn known_agent_prefers_more_specific_token_over_its_substring() {
+    let enricher = Enricher::new(Arc::new(NoGeo), 8);
+
+    let mut ev = base_event();
+    ev.user_agent =
+        Some("Mozilla/5.0 (Applebot-Extended/0.1; +http://www.apple.com/go/applebot)".into());
+    let result = enricher.enrich(&ev);
+    assert_eq!(
+        result.agent_name.as_deref(),
+        Some("Applebot-Extended"),
+        "Applebot-Extended must not be masked by the plain Applebot token"
+    );
+
+    let mut ev = base_event();
+    ev.user_agent = Some("Mozilla/5.0 (compatible; GrokBot/1.0)".into());
+    let result = enricher.enrich(&ev);
+    assert_eq!(
+        result.agent_name.as_deref(),
+        Some("GrokBot"),
+        "GrokBot must not be masked by the plain Grok token"
+    );
+}
+
+#[test]
+fn known_agent_covers_recently_added_ai_labs() {
+    let enricher = Enricher::new(Arc::new(NoGeo), 8);
+
+    let cases = [
+        (
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
+            "ClaudeBot",
+        ),
+        (
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; MistralAI-User/1.0; +https://docs.mistral.ai/robots)",
+            "MistralAI-User",
+        ),
+        (
+            "DeepSeekBot/1.0 (+https://deepseek.com/deepseekbot)",
+            "DeepSeekBot",
+        ),
+        (
+            "Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)",
+            "PerplexityBot",
+        ),
+        (
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Meta-ExternalFetcher/1.1)",
+            "Meta-ExternalFetcher",
+        ),
+        ("bigsur.ai (+https://www.bigsur.ai)", "bigsur.ai"),
+    ];
+
+    for (ua, expected) in cases {
+        let mut ev = base_event();
+        ev.user_agent = Some(ua.into());
+        let result = enricher.enrich(&ev);
+        assert_eq!(
+            result.agent_name.as_deref(),
+            Some(expected),
+            "UA {ua:?} should resolve to {expected}"
+        );
+    }
+}
+
+#[test]
 fn normal_browser_has_no_agent_name_and_is_not_a_bot() {
     let enricher = Enricher::new(Arc::new(NoGeo), 8);
     let mut ev = base_event();

--- a/crates/traffic/src/enrich/tests.rs
+++ b/crates/traffic/src/enrich/tests.rs
@@ -106,6 +106,41 @@ fn detects_bot_via_woothee() {
 }
 
 #[test]
+fn known_agent_detected_from_ua_substring() {
+    let enricher = Enricher::new(Arc::new(NoGeo), 8);
+    let mut ev = base_event();
+    ev.user_agent =
+        Some("Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.1; +https://openai.com/gptbot".into());
+
+    let result = enricher.enrich(&ev);
+
+    assert_eq!(
+        result.agent_name.as_deref(),
+        Some("GPTBot"),
+        "a UA containing GPTBot must resolve to the canonical agent name"
+    );
+    assert!(result.bot, "a matched known agent must imply bot traffic");
+}
+
+#[test]
+fn normal_browser_has_no_agent_name_and_is_not_a_bot() {
+    let enricher = Enricher::new(Arc::new(NoGeo), 8);
+    let mut ev = base_event();
+    ev.user_agent = Some(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+            .into(),
+    );
+
+    let result = enricher.enrich(&ev);
+
+    assert_eq!(
+        result.agent_name, None,
+        "a normal Chrome UA matches no agent"
+    );
+    assert!(!result.bot);
+}
+
+#[test]
 fn ua_cache_memoizes() {
     let enricher = Enricher::new(Arc::new(NoGeo), 8);
     let mut ev = base_event();

--- a/crates/traffic/src/enrich/tests.rs
+++ b/crates/traffic/src/enrich/tests.rs
@@ -142,7 +142,25 @@ fn known_agent_prefers_more_specific_token_over_its_substring() {
     assert_eq!(
         result.agent_name.as_deref(),
         Some("GrokBot"),
-        "GrokBot must not be masked by the plain Grok token"
+        "GrokBot must resolve to its own canonical name"
+    );
+}
+
+#[test]
+fn known_agent_does_not_false_positive_on_unrelated_products_containing_grok() {
+    let enricher = Enricher::new(Arc::new(NoGeo), 8);
+    let mut ev = base_event();
+    ev.user_agent = Some(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) NotGrokClient/1.0 AppleWebKit/537.36 Chrome/91.0"
+            .into(),
+    );
+
+    let result = enricher.enrich(&ev);
+
+    assert_eq!(
+        result.agent_name, None,
+        "there is no bare 'grok' token, so an unrelated product name containing \
+         'grok' must not be misclassified as the xAI crawler"
     );
 }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -443,7 +443,11 @@ paths:
           required: true
           description: |
             One of: status, method, country, referer, browser, os, device,
-            protocol, scheme, tls, cache, bot.
+            protocol, scheme, tls, cache, bot, agent, ip, useragent. The
+            `agent` dimension holds the bot/AI-agent name (e.g. GPTBot,
+            ClaudeBot) and is only present for bot traffic. `ip` holds the
+            resolved real client IP (respecting Cloudflare CF-Connecting-IP
+            and X-Forwarded-For); `useragent` holds the raw User-Agent header.
           schema:
             type: string
           example: country
@@ -575,7 +579,11 @@ paths:
           required: true
           description: |
             One of: status, method, country, referer, browser, os, device,
-            protocol, scheme, tls, cache, bot.
+            protocol, scheme, tls, cache, bot, agent, ip, useragent. The
+            `agent` dimension holds the bot/AI-agent name (e.g. GPTBot,
+            ClaudeBot) and is only present for bot traffic. `ip` holds the
+            resolved real client IP (respecting Cloudflare CF-Connecting-IP
+            and X-Forwarded-For); `useragent` holds the raw User-Agent header.
           schema:
             type: string
           example: country
@@ -1058,10 +1066,19 @@ components:
       description: |
         One row of the top-paths table, summed over every bucket in the
         range. p99 is deliberately omitted to keep large responses small.
+        Rows are keyed by (app, path), so on the server-wide endpoint the same
+        path served by different apps stays a separate row per app.
       properties:
         path:
           type: string
           example: /api/checkout
+        app:
+          type: string
+          description: |
+            The app (Coolify app UUID, or host for Caddy) that served this
+            path. Always the queried app on a per-app endpoint; attributes each
+            path to its owning app on the server-wide endpoint.
+          example: jc4wsgs
         requests:
           type: integer
           format: int64


### PR DESCRIPTION
## Summary
- Detect bot/AI-agent User-Agents (GPTBot, ClaudeBot, Googlebot, PerplexityBot, etc.) via a known-agent substring table, used as a fallback when Cloudflare's verified-bot header is absent
- Record three new breakdown dimensions per request: `agent` (bot/AI-agent name), `ip` (resolved real client IP), `useragent` (raw UA string)
- Server-wide top-paths now groups by `(app, path)` instead of `path` alone, so the same path served by different apps is attributed to its own app instead of being merged

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] Verify `/api/traffic/*` breakdown responses include `agent`, `ip`, `useragent` dimensions
- [ ] Verify server-wide top-paths response includes an `app` field per path and no longer merges identical paths across apps