### PR TITLE
feat(traffic): add aggregate /traffic/dashboard endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -795,20 +795,35 @@ Additive: older Coolify keeps calling the individual endpoints; new Coolify call
 
 **Response:** a single object. `overview`, `paths`, and each `breakdowns` dimension follow `from`/`to`; `series` follows `range`. The server-wide variant includes `apps` (every app with traffic, ranked by requests desc, capped at `apps_limit`); the per-app variant omits `apps` entirely. An empty range returns `200` with zeroed/empty members — never `404`.
 
+Each member is verbatim the shape of its standalone endpoint (see the sections above): `overview` is [Get App Traffic Overview](#get-app-traffic-overview); `paths` is [Get App Top Paths](#get-app-top-paths); each `breakdowns.<dim>` entry is `{ "value", "requests", "bytes_out" }`; `series` is [Get App Status-Class Time Series](#get-app-status-class-time-series); `attribution` is the bare string from [Get GeoIP Attribution](#get-geoip-attribution) (or `null`). Only apps with traffic in the range appear in `apps`.
+
 ```json
 {
-  "overview":    { /* identical to GET /traffic/overview */ },
-  "paths":       [ /* identical to GET /traffic/paths */ ],
-  "breakdowns":  { "country": [], "referer": [], "browser": [], "os": [],
-                   "device": [], "protocol": [], "cache": [], "status": [],
-                   "agent": [], "ip": [], "useragent": [] },
-  "series":      [ /* identical to GET /traffic/series */ ],
-  "attribution": "This product includes GeoLite2 data created by MaxMind, ...",
-  "apps":        [ { "uuid": "jc4wsgs", "overview": { /* per-app overview */ } } ]
+  "overview": {
+    "requests": 128340,
+    "bytes_in": 15200000,
+    "bytes_out": 981000000,
+    "status": { "s2xx": 120000, "s3xx": 4000, "s4xx": 4200, "s5xx": 140 },
+    "latency": { "p50": 42.0, "p95": 118.0, "p99": 240.0 },
+    "unique_visitors": 8421
+  },
+  "paths": [
+    { "path": "/api/checkout", "app": "jc4wsgs", "requests": 42000, "bytes_out": 320000000, "p50": 40.0, "p95": 110.0 }
+  ],
+  "breakdowns": {
+    "country": [ { "value": "US", "requests": 42000, "bytes_out": 320000000 } ],
+    "referer": [], "browser": [], "os": [], "device": [], "protocol": [],
+    "cache": [], "status": [], "agent": [], "ip": [], "useragent": []
+  },
+  "series": [
+    { "bucket": 1723334400000, "requests": 46, "bytes_in": 12800, "bytes_out": 402000, "s2xx": 42, "s3xx": 3, "s4xx": 1, "s5xx": 0, "unique_visitors": 37, "p95": 118.0 }
+  ],
+  "attribution": "This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com",
+  "apps": [
+    { "uuid": "jc4wsgs", "overview": { "requests": 128340, "bytes_in": 15200000, "bytes_out": 981000000, "status": { "s2xx": 120000, "s3xx": 4000, "s4xx": 4200, "s5xx": 140 }, "latency": { "p50": 42.0, "p95": 118.0, "p99": 240.0 }, "unique_visitors": 8421 } }
+  ]
 }
 ```
-
-Each `breakdowns.<dim>` entry is `{ "value", "requests", "bytes_out" }`; `attribution` is the bare string from [Get GeoIP Attribution](#get-geoip-attribution) (or `null`).
 
 **Example:**
 ```bash

--- a/API.md
+++ b/API.md
@@ -770,6 +770,54 @@ curl -H "Authorization: Bearer YOUR_TOKEN" \
 
 ---
 
+### Get Aggregate Dashboard
+
+Bundle every traffic shape above into a single response, so a dashboard can replace ~15 separate requests with one. Each member is **verbatim** the shape of its standalone endpoint — the same server-side merges (t-digest latency, HLL uniques merged, never re-summed).
+
+Additive: older Coolify keeps calling the individual endpoints; new Coolify calls this first and falls back to them on `404`.
+
+**Endpoint:** `GET /api/traffic/dashboard` (server-wide) and `GET /api/app/:uuid/traffic/dashboard` (per app)
+
+**Path Parameters** (per-app variant only):
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `uuid` | string | Yes | Coolify app UUID (or host, for Caddy) |
+
+**Query Parameters:**
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `from` | string | No | epoch | ISO-8601 Zulu start bound for overview/paths/breakdowns |
+| `to` | string | No | now | ISO-8601 Zulu end bound for overview/paths/breakdowns |
+| `range` | string | No | `24h` | Series window + granularity: `24h` (hourly), `7d`/`30d` (daily) |
+| `paths_limit` | integer | No | `50` | Top-N cap for `paths` (max `1000`) |
+| `breakdown_limit` | integer | No | `50` | Top-N cap per breakdown dimension (max `1000`) |
+| `apps_limit` | integer | No | `200` | Cap for the `apps` leaderboard (max `1000`; server-wide only) |
+
+**Response:** a single object. `overview`, `paths`, and each `breakdowns` dimension follow `from`/`to`; `series` follows `range`. The server-wide variant includes `apps` (every app with traffic, ranked by requests desc, capped at `apps_limit`); the per-app variant omits `apps` entirely. An empty range returns `200` with zeroed/empty members — never `404`.
+
+```json
+{
+  "overview":    { /* identical to GET /traffic/overview */ },
+  "paths":       [ /* identical to GET /traffic/paths */ ],
+  "breakdowns":  { "country": [], "referer": [], "browser": [], "os": [],
+                   "device": [], "protocol": [], "cache": [], "status": [],
+                   "agent": [], "ip": [], "useragent": [] },
+  "series":      [ /* identical to GET /traffic/series */ ],
+  "attribution": "This product includes GeoLite2 data created by MaxMind, ...",
+  "apps":        [ { "uuid": "jc4wsgs", "overview": { /* per-app overview */ } } ]
+}
+```
+
+Each `breakdowns.<dim>` entry is `{ "value", "requests", "bytes_out" }`; `attribution` is the bare string from [Get GeoIP Attribution](#get-geoip-attribution) (or `null`).
+
+**Example:**
+```bash
+curl -H "Authorization: Bearer YOUR_TOKEN" \
+  "http://localhost:8888/api/traffic/dashboard?range=7d&paths_limit=25"
+```
+
+---
+
 ## Debug Endpoints
 
 Debug endpoints are only available when the `DEBUG` environment variable is set to `true`.

--- a/crates/api/src/routes/traffic.rs
+++ b/crates/api/src/routes/traffic.rs
@@ -10,15 +10,16 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Deserialize;
-use store::traffic::{BreakdownRow, PathRow, StatsRow, Tier};
+use store::traffic::{AnalyticsStore, BreakdownRow, PathRow, StatsRow, Tier};
 use traffic::sketches::{LatencyDigest, Uniques};
 
 use crate::AppState;
 use crate::routes::cpu::{HistoryQuery, internal_error, resolve_range};
 use crate::time::now_ms;
 use crate::types::{
-    ErrorBody, TrafficAttribution, TrafficBreakdownEntry, TrafficLatency, TrafficOverview,
-    TrafficPath, TrafficSeriesBucket, TrafficStatusBreakdown,
+    ErrorBody, TrafficAppEntry, TrafficAttribution, TrafficBreakdownEntry, TrafficBreakdowns,
+    TrafficDashboard, TrafficLatency, TrafficOverview, TrafficPath, TrafficSeriesBucket,
+    TrafficStatusBreakdown,
 };
 
 const MIN_MS: i64 = 60_000;
@@ -35,6 +36,9 @@ const DEFAULT_LIMIT: usize = 50;
 /// Upper bound on the caller-supplied `limit`, so one request cannot ask the
 /// handler to materialize an unbounded result set.
 const MAX_LIMIT: usize = 1_000;
+
+/// Default cap on the dashboard's app leaderboard when `apps_limit` is absent.
+const DEFAULT_APPS_LIMIT: usize = 200;
 
 /// SQL `LIMIT` on `paths_range`/`breakdown_range`, purely a memory backstop
 /// against a pathological span. Real queries fall far below it; hitting it is
@@ -67,12 +71,15 @@ pub fn routes() -> Router<Arc<AppState>> {
             get(breakdown),
         )
         .route("/api/app/{uuid}/traffic/series", get(app_series))
+        .route("/api/app/{uuid}/traffic/dashboard", get(app_dashboard))
         // Server-wide variants: same shapes, merged across every app/host.
         .route("/api/traffic/overview", get(server_overview))
         .route("/api/traffic/paths", get(server_paths))
         .route("/api/traffic/breakdown/{dimension}", get(server_breakdown))
         .route("/api/traffic/series", get(series))
         .route("/api/traffic/attribution", get(attribution))
+        // One request that bundles every shape above, for Coolify's dashboard.
+        .route("/api/traffic/dashboard", get(server_dashboard))
 }
 
 /// `from`/`to` plus a top-N cap, for the two ranked endpoints.
@@ -103,6 +110,22 @@ impl TopQuery {
 #[derive(Debug, Deserialize)]
 pub struct SeriesQuery {
     pub range: Option<String>,
+}
+
+/// Every windowing knob the dashboard bundles: `from`/`to` drive the overview,
+/// paths, and breakdowns; `range` drives the series (independently, like the
+/// standalone `/series`); the three limits cap each ranked member. All are
+/// `Option<String>` so `?from=` / `?paths_limit=` (empty) fall back to the
+/// default rather than being rejected — the same courtesy the other endpoints
+/// extend.
+#[derive(Debug, Deserialize)]
+pub struct DashboardQuery {
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub range: Option<String>,
+    pub paths_limit: Option<String>,
+    pub breakdown_limit: Option<String>,
+    pub apps_limit: Option<String>,
 }
 
 /// Floors `ts` to the start of its containing `width`-wide bucket. `div_euclid`
@@ -265,6 +288,19 @@ fn aggregate_series(
 fn resolve_limit(raw: Option<&str>) -> Result<usize, Response> {
     let Some(s) = raw.filter(|s| !s.is_empty()) else {
         return Ok(DEFAULT_LIMIT);
+    };
+    match s.parse::<usize>() {
+        Ok(0) | Err(_) => Err(bad_limit()),
+        Ok(n) => Ok(n.min(MAX_LIMIT)),
+    }
+}
+
+/// Like [`resolve_limit`] but defaults to [`DEFAULT_APPS_LIMIT`] when absent.
+/// Shares the `0`/non-numeric rejection and the [`MAX_LIMIT`] ceiling.
+#[allow(clippy::result_large_err)]
+fn resolve_apps_limit(raw: Option<&str>) -> Result<usize, Response> {
+    let Some(s) = raw.filter(|s| !s.is_empty()) else {
+        return Ok(DEFAULT_APPS_LIMIT);
     };
     match s.parse::<usize>() {
         Ok(0) | Err(_) => Err(bad_limit()),
@@ -795,6 +831,285 @@ where
         (std::cmp::Reverse(reqs), k)
     });
     rows.truncate(limit);
+}
+
+// --- Aggregate dashboard ----------------------------------------------------
+
+/// Selects whether a dashboard query runs server-wide (every app/host) or is
+/// filtered to one app, unifying the two store method families behind one
+/// interface so [`build_dashboard`] keeps a single code path. Each method is
+/// exactly the call the corresponding standalone handler already makes.
+enum Target {
+    Server,
+    App(String),
+}
+
+impl Target {
+    /// Label for the truncation warning: `*` server-wide, else the app.
+    fn label(&self) -> &str {
+        match self {
+            Target::Server => "*",
+            Target::App(app) => app,
+        }
+    }
+
+    fn stats(
+        &self,
+        a: &AnalyticsStore,
+        tier: Tier,
+        lo: i64,
+        hi: i64,
+    ) -> Result<Vec<StatsRow>, store::StoreError> {
+        match self {
+            Target::Server => a.stats_rows_between(tier, lo, hi),
+            Target::App(app) => a.stats_range(tier, app, lo, hi),
+        }
+    }
+
+    fn paths(
+        &self,
+        a: &AnalyticsStore,
+        tier: Tier,
+        lo: i64,
+        hi: i64,
+        budget: usize,
+    ) -> Result<Vec<PathRow>, store::StoreError> {
+        match self {
+            Target::Server => a.paths_rows_between(tier, lo, hi),
+            Target::App(app) => a.paths_range(tier, app, lo, hi, budget),
+        }
+    }
+
+    fn breakdown(
+        &self,
+        a: &AnalyticsStore,
+        tier: Tier,
+        dim: &str,
+        lo: i64,
+        hi: i64,
+        budget: usize,
+    ) -> Result<Vec<BreakdownRow>, store::StoreError> {
+        match self {
+            Target::Server => a.breakdown_dim_rows_between(tier, dim, lo, hi, budget),
+            Target::App(app) => a.breakdown_range(tier, app, dim, lo, hi, budget),
+        }
+    }
+}
+
+/// The already-resolved windowing for one dashboard query. `from`/`to` bound
+/// the overview/paths/breakdowns; `series_width`/`series_count` come from
+/// `range` and drive only the series (whose window is derived from `now`).
+struct DashboardParams {
+    from: i64,
+    to: i64,
+    now: i64,
+    paths_limit: usize,
+    breakdown_limit: usize,
+    series_width: i64,
+    series_count: usize,
+    apps_limit: usize,
+}
+
+/// Assembles the whole dashboard in one blocking pass, reusing the exact
+/// merge helpers the standalone endpoints use — nothing is re-summed. Returns
+/// `attribution: None`; the handler fills it in from `AppState` afterwards.
+fn build_dashboard(
+    analytics: &AnalyticsStore,
+    target: &Target,
+    p: &DashboardParams,
+    include_apps: bool,
+) -> Result<TrafficDashboard, store::StoreError> {
+    // Overview — same tier union + sketch merge as `overview`/`server_overview`.
+    let mut stats_rows = Vec::new();
+    for (tier, lo, hi) in tier_reads(p.from, p.to) {
+        stats_rows.extend(target.stats(analytics, tier, lo, hi)?);
+    }
+    let overview = summarize_stats(stats_rows);
+
+    // Paths.
+    let mut path_rows = Vec::new();
+    for (tier, lo, hi) in tier_reads(p.from, p.to) {
+        let r = target.paths(analytics, tier, lo, hi, MAX_SCAN_ROWS)?;
+        warn_if_truncated("dashboard_paths", target.label(), r.len(), MAX_SCAN_ROWS);
+        path_rows.extend(r);
+    }
+    let paths = top_paths(path_rows, p.paths_limit);
+
+    // Breakdowns — one ranked list per dimension. The dimension set is the
+    // struct's own fields, so it stays in lockstep with Coolify's list.
+    let dim = |name: &str| -> Result<Vec<TrafficBreakdownEntry>, store::StoreError> {
+        let mut rows = Vec::new();
+        for (tier, lo, hi) in tier_reads(p.from, p.to) {
+            let r = target.breakdown(analytics, tier, name, lo, hi, MAX_SCAN_ROWS)?;
+            warn_if_truncated(
+                "dashboard_breakdown",
+                target.label(),
+                r.len(),
+                MAX_SCAN_ROWS,
+            );
+            rows.extend(r);
+        }
+        Ok(top_breakdown(rows, p.breakdown_limit))
+    };
+    let breakdowns = TrafficBreakdowns {
+        country: dim("country")?,
+        referer: dim("referer")?,
+        browser: dim("browser")?,
+        os: dim("os")?,
+        device: dim("device")?,
+        protocol: dim("protocol")?,
+        cache: dim("cache")?,
+        status: dim("status")?,
+        agent: dim("agent")?,
+        ip: dim("ip")?,
+        useragent: dim("useragent")?,
+    };
+
+    // Series — its window derives from `now`, independent of `from`/`to`.
+    let series_end = floor_to(p.now, p.series_width);
+    let series_from = series_end - (p.series_count as i64 - 1) * p.series_width;
+    let mut series_rows = Vec::new();
+    for (tier, lo, hi) in tier_reads_for(p.series_width, series_from, p.now) {
+        series_rows.extend(target.stats(analytics, tier, lo, hi)?);
+    }
+    let series = aggregate_series(series_rows, p.now, p.series_width, p.series_count);
+
+    let apps = if include_apps {
+        Some(app_leaderboard(analytics, p)?)
+    } else {
+        None
+    };
+
+    Ok(TrafficDashboard {
+        overview,
+        paths,
+        breakdowns,
+        series,
+        attribution: None,
+        apps,
+    })
+}
+
+/// Per-app overview for every app with traffic, ranked by requests desc
+/// (ties broken by uuid asc for determinism) and capped at `apps_limit`.
+/// Each overview is a real sketch merge, not a re-sum of anything.
+fn app_leaderboard(
+    analytics: &AnalyticsStore,
+    p: &DashboardParams,
+) -> Result<Vec<TrafficAppEntry>, store::StoreError> {
+    let uuids = analytics.apps()?;
+    let mut entries: Vec<TrafficAppEntry> = Vec::with_capacity(uuids.len());
+    for uuid in uuids {
+        let mut rows = Vec::new();
+        for (tier, lo, hi) in tier_reads(p.from, p.to) {
+            rows.extend(analytics.stats_range(tier, &uuid, lo, hi)?);
+        }
+        entries.push(TrafficAppEntry {
+            uuid,
+            overview: summarize_stats(rows),
+        });
+    }
+    entries.sort_by(|a, b| {
+        b.overview
+            .requests
+            .cmp(&a.overview.requests)
+            .then_with(|| a.uuid.cmp(&b.uuid))
+    });
+    entries.truncate(p.apps_limit);
+    Ok(entries)
+}
+
+/// Server-wide dashboard: every member merged across all apps, plus the app
+/// leaderboard.
+async fn server_dashboard(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<DashboardQuery>,
+) -> Response {
+    run_dashboard(state, Target::Server, true, q).await
+}
+
+/// Per-app dashboard: same members filtered to one app, `apps` omitted.
+async fn app_dashboard(
+    Path(app): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<DashboardQuery>,
+) -> Response {
+    run_dashboard(state, Target::App(app), false, q).await
+}
+
+/// Shared body for both dashboard handlers: resolve every knob (any invalid
+/// one is a 400), snapshot the GeoIP attribution, then build the payload in a
+/// single blocking task under one query permit. A missing analytics store is
+/// the only 404 — an empty range still returns 200 with zeroed/empty members.
+async fn run_dashboard(
+    state: Arc<AppState>,
+    target: Target,
+    include_apps: bool,
+    q: DashboardQuery,
+) -> Response {
+    let Some(analytics) = state.analytics.clone() else {
+        return analytics_disabled();
+    };
+    let (from, to) = match resolve_range(
+        &HistoryQuery {
+            from: q.from,
+            to: q.to,
+        },
+        DEFAULT_FROM,
+    ) {
+        Ok(r) => r,
+        Err(resp) => return resp,
+    };
+    let paths_limit = match resolve_limit(q.paths_limit.as_deref()) {
+        Ok(n) => n,
+        Err(resp) => return resp,
+    };
+    let breakdown_limit = match resolve_limit(q.breakdown_limit.as_deref()) {
+        Ok(n) => n,
+        Err(resp) => return resp,
+    };
+    let apps_limit = match resolve_apps_limit(q.apps_limit.as_deref()) {
+        Ok(n) => n,
+        Err(resp) => return resp,
+    };
+    let (series_width, series_count) = match resolve_series(q.range.as_deref()) {
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
+
+    let attribution = state
+        .geoip_attribution
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let params = DashboardParams {
+        from,
+        to,
+        now: now_ms(),
+        paths_limit,
+        breakdown_limit,
+        series_width,
+        series_count,
+        apps_limit,
+    };
+
+    let permit = match state.analytics_queries.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(e) => return internal_error(e),
+    };
+    let result = tokio::task::spawn_blocking(move || {
+        build_dashboard(&analytics, &target, &params, include_apps)
+    })
+    .await;
+    drop(permit);
+    match result {
+        Ok(Ok(mut dash)) => {
+            dash.attribution = attribution;
+            Json(dash).into_response()
+        }
+        Ok(Err(e)) => internal_error(e),
+        Err(e) => internal_error(e),
+    }
 }
 
 #[cfg(test)]

--- a/crates/api/src/routes/traffic.rs
+++ b/crates/api/src/routes/traffic.rs
@@ -454,7 +454,7 @@ async fn overview(
         for (tier, lo, hi) in tier_reads(from, to) {
             rows.extend(analytics.stats_range(tier, &app, lo, hi)?);
         }
-        Ok::<_, store::StoreError>(summarize_stats(rows))
+        Ok::<_, store::StoreError>(summarize_stats(&rows))
     })
     .await;
     drop(permit);
@@ -570,7 +570,7 @@ async fn server_overview(
         for (tier, lo, hi) in tier_reads(from, to) {
             rows.extend(analytics.stats_rows_between(tier, lo, hi)?);
         }
-        Ok::<_, store::StoreError>(summarize_stats(rows))
+        Ok::<_, store::StoreError>(summarize_stats(&rows))
     })
     .await;
     drop(permit);
@@ -667,7 +667,7 @@ async fn server_breakdown(
 /// skipped for that sketch, and logged. One corrupted page must not turn a
 /// dashboard query into a 500 — the same "skip malformed data, don't crash"
 /// rule the parser and compaction paths follow.
-fn summarize_stats(rows: Vec<StatsRow>) -> TrafficOverview {
+fn summarize_stats(rows: &[StatsRow]) -> TrafficOverview {
     let mut requests = 0i64;
     let mut bytes_in = 0i64;
     let mut bytes_out = 0i64;
@@ -681,7 +681,7 @@ fn summarize_stats(rows: Vec<StatsRow>) -> TrafficOverview {
     // this a plain fold; an HLL union with an empty sketch is a no-op.
     let mut visitors = Uniques::new();
 
-    for r in &rows {
+    for r in rows {
         requests = requests.saturating_add(r.requests);
         bytes_in = bytes_in.saturating_add(r.bytes_in);
         bytes_out = bytes_out.saturating_add(r.bytes_out);
@@ -920,11 +920,13 @@ fn build_dashboard(
     include_apps: bool,
 ) -> Result<TrafficDashboard, store::StoreError> {
     // Overview — same tier union + sketch merge as `overview`/`server_overview`.
+    // On the server-wide target these rows span every app, so the leaderboard
+    // below reuses them (grouped by app) instead of re-querying per app.
     let mut stats_rows = Vec::new();
     for (tier, lo, hi) in tier_reads(p.from, p.to) {
         stats_rows.extend(target.stats(analytics, tier, lo, hi)?);
     }
-    let overview = summarize_stats(stats_rows);
+    let overview = summarize_stats(&stats_rows);
 
     // Paths.
     let mut path_rows = Vec::new();
@@ -974,8 +976,11 @@ fn build_dashboard(
     }
     let series = aggregate_series(series_rows, p.now, p.series_width, p.series_count);
 
+    // `include_apps` is only ever set for the server-wide target, whose
+    // `stats_rows` already covers every app — so grouping them by app costs no
+    // extra query, however many apps exist.
     let apps = if include_apps {
-        Some(app_leaderboard(analytics, p)?)
+        Some(app_leaderboard(stats_rows, p.apps_limit))
     } else {
         None
     };
@@ -990,33 +995,34 @@ fn build_dashboard(
     })
 }
 
-/// Per-app overview for every app with traffic, ranked by requests desc
-/// (ties broken by uuid asc for determinism) and capped at `apps_limit`.
-/// Each overview is a real sketch merge, not a re-sum of anything.
-fn app_leaderboard(
-    analytics: &AnalyticsStore,
-    p: &DashboardParams,
-) -> Result<Vec<TrafficAppEntry>, store::StoreError> {
-    let uuids = analytics.apps()?;
-    let mut entries: Vec<TrafficAppEntry> = Vec::with_capacity(uuids.len());
-    for uuid in uuids {
-        let mut rows = Vec::new();
-        for (tier, lo, hi) in tier_reads(p.from, p.to) {
-            rows.extend(analytics.stats_range(tier, &uuid, lo, hi)?);
-        }
-        entries.push(TrafficAppEntry {
-            uuid,
-            overview: summarize_stats(rows),
-        });
+/// Builds the leaderboard from the server-wide stats rows already fetched for
+/// the overview: groups them by app, merges each group into a per-app overview
+/// (a real sketch merge — grouping by `app` reproduces exactly what a per-app
+/// `stats_range` scan would have returned), then ranks by requests desc (ties
+/// broken by uuid asc for determinism) and caps at `apps_limit`.
+///
+/// Only apps with traffic in the range appear — an idle app is simply absent
+/// from a request-ranked leaderboard rather than a zeroed tail entry.
+fn app_leaderboard(rows: Vec<StatsRow>, apps_limit: usize) -> Vec<TrafficAppEntry> {
+    let mut by_app: HashMap<String, Vec<StatsRow>> = HashMap::new();
+    for r in rows {
+        by_app.entry(r.app.clone()).or_default().push(r);
     }
+    let mut entries: Vec<TrafficAppEntry> = by_app
+        .into_iter()
+        .map(|(uuid, rows)| TrafficAppEntry {
+            uuid,
+            overview: summarize_stats(&rows),
+        })
+        .collect();
     entries.sort_by(|a, b| {
         b.overview
             .requests
             .cmp(&a.overview.requests)
             .then_with(|| a.uuid.cmp(&b.uuid))
     });
-    entries.truncate(p.apps_limit);
-    Ok(entries)
+    entries.truncate(apps_limit);
+    entries
 }
 
 /// Server-wide dashboard: every member merged across all apps, plus the app
@@ -1068,9 +1074,16 @@ async fn run_dashboard(
         Ok(n) => n,
         Err(resp) => return resp,
     };
-    let apps_limit = match resolve_apps_limit(q.apps_limit.as_deref()) {
-        Ok(n) => n,
-        Err(resp) => return resp,
+    // Only meaningful on the server-wide variant, so the per-app endpoint must
+    // ignore it entirely — even an invalid value — matching the documented
+    // "ignored for this variant" contract.
+    let apps_limit = if include_apps {
+        match resolve_apps_limit(q.apps_limit.as_deref()) {
+            Ok(n) => n,
+            Err(resp) => return resp,
+        }
+    } else {
+        DEFAULT_APPS_LIMIT
     };
     let (series_width, series_count) = match resolve_series(q.range.as_deref()) {
         Ok(v) => v,

--- a/crates/api/src/routes/traffic.rs
+++ b/crates/api/src/routes/traffic.rs
@@ -928,11 +928,16 @@ fn build_dashboard(
     }
     let overview = summarize_stats(&stats_rows);
 
-    // Paths.
+    // Paths. Only the per-app read applies the `LIMIT budget`; the server-wide
+    // `paths_rows_between` is unbounded, so a truncation warning there would be
+    // a false signal (nothing was cut).
+    let path_budget_applies = matches!(target, Target::App(_));
     let mut path_rows = Vec::new();
     for (tier, lo, hi) in tier_reads(p.from, p.to) {
         let r = target.paths(analytics, tier, lo, hi, MAX_SCAN_ROWS)?;
-        warn_if_truncated("dashboard_paths", target.label(), r.len(), MAX_SCAN_ROWS);
+        if path_budget_applies {
+            warn_if_truncated("dashboard_paths", target.label(), r.len(), MAX_SCAN_ROWS);
+        }
         path_rows.extend(r);
     }
     let paths = top_paths(path_rows, p.paths_limit);

--- a/crates/api/src/routes/traffic/tests.rs
+++ b/crates/api/src/routes/traffic/tests.rs
@@ -1073,6 +1073,17 @@ async fn app_dashboard_filters_and_omits_leaderboard() {
     for p in j["paths"].as_array().unwrap() {
         assert_eq!(p["app"], "app-a");
     }
+    // Breakdowns are app-scoped: app-a's country US is 9 (5 + 4), not the 15
+    // that includes app-b's 6 — so the dimension is filtered, not server-wide.
+    let country = j["breakdowns"]["country"].as_array().unwrap();
+    let us = country
+        .iter()
+        .find(|e| e["value"] == "US")
+        .expect("US present");
+    assert_eq!(us["requests"], 9, "country breakdown filtered to app-a");
+    // Series stays fixed-length (its window is app-filtered through the same
+    // Target::App path as overview/paths).
+    assert_eq!(j["series"].as_array().unwrap().len(), 24);
     // No leaderboard on the per-app variant.
     assert!(j.get("apps").is_none(), "apps must be omitted for per-app");
 }

--- a/crates/api/src/routes/traffic/tests.rs
+++ b/crates/api/src/routes/traffic/tests.rs
@@ -539,6 +539,8 @@ async fn every_endpoint_404s_when_analytics_is_disabled() {
         "/api/traffic/paths",
         "/api/traffic/breakdown/country",
         "/api/traffic/attribution",
+        "/api/traffic/dashboard",
+        "/api/app/app-a/traffic/dashboard",
     ] {
         let (s, j) = get_with(state(None), uri).await;
         assert_eq!(s, StatusCode::NOT_FOUND, "{uri}");
@@ -1002,4 +1004,127 @@ async fn series_rejects_unknown_range() {
 async fn series_404_when_analytics_disabled() {
     let (status, _) = get_with(state(None), "/api/traffic/series").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+// --- Dashboard --------------------------------------------------------------
+
+/// The server-wide dashboard bundles the exact shapes of the standalone
+/// endpoints, so each member must match what its own endpoint returns.
+#[tokio::test]
+async fn server_dashboard_bundles_every_member() {
+    let (s, j) = get(&format!("/api/traffic/dashboard?{RANGE}")).await;
+    assert_eq!(s, StatusCode::OK);
+
+    // Overview identical to GET /traffic/overview (47 across every app/host).
+    assert_eq!(j["overview"]["requests"], 47);
+    assert_eq!(j["overview"]["status"]["s2xx"], 41);
+
+    // Paths identical to GET /traffic/paths: /a stays per-app, 3 rows.
+    let paths = j["paths"].as_array().unwrap();
+    assert_eq!(paths.len(), 3);
+    assert_eq!(paths[0]["path"], "/b");
+    assert_eq!(paths[0]["requests"], 22);
+
+    // Breakdowns: all eleven dimensions present; country merged across apps.
+    let bds = &j["breakdowns"];
+    for dim in [
+        "country",
+        "referer",
+        "browser",
+        "os",
+        "device",
+        "protocol",
+        "cache",
+        "status",
+        "agent",
+        "ip",
+        "useragent",
+    ] {
+        assert!(bds[dim].is_array(), "breakdown '{dim}' missing");
+    }
+    let country = bds["country"].as_array().unwrap();
+    assert_eq!(country[0]["value"], "US");
+    assert_eq!(country[0]["requests"], 15);
+
+    // Series is the fixed-length zero-filled array (default 24h → 24 buckets).
+    assert_eq!(j["series"].as_array().unwrap().len(), 24);
+
+    // attribution flattened to the bare value (null here — GeoIP not resolved).
+    assert!(j["attribution"].is_null());
+
+    // Leaderboard ranked by requests desc: app-a (40) then app-b (7).
+    let apps = j["apps"].as_array().unwrap();
+    assert_eq!(apps.len(), 2);
+    assert_eq!(apps[0]["uuid"], "app-a");
+    assert_eq!(apps[0]["overview"]["requests"], 40);
+    assert_eq!(apps[1]["uuid"], "app-b");
+    assert_eq!(apps[1]["overview"]["requests"], 7);
+}
+
+/// The per-app variant filters every member to one app and omits `apps`.
+#[tokio::test]
+async fn app_dashboard_filters_and_omits_leaderboard() {
+    let (s, j) = get(&format!("/api/app/app-a/traffic/dashboard?{RANGE}")).await;
+    assert_eq!(s, StatusCode::OK);
+
+    // app-a only: 10 + 30 = 40, not the 47 that includes app-b.
+    assert_eq!(j["overview"]["requests"], 40);
+    // Every path row belongs to app-a.
+    for p in j["paths"].as_array().unwrap() {
+        assert_eq!(p["app"], "app-a");
+    }
+    // No leaderboard on the per-app variant.
+    assert!(j.get("apps").is_none(), "apps must be omitted for per-app");
+}
+
+/// An out-of-range window returns 200 with zeroed/empty members, never 404.
+#[tokio::test]
+async fn dashboard_empty_range_is_zeroed_not_404() {
+    let (s, j) =
+        get("/api/traffic/dashboard?from=2000-01-01T00:00:00Z&to=2000-01-02T00:00:00Z").await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(j["overview"]["requests"], 0);
+    assert_eq!(j["paths"].as_array().unwrap().len(), 0);
+    assert_eq!(j["breakdowns"]["country"].as_array().unwrap().len(), 0);
+    // Series stays fixed-length and zero-filled.
+    assert_eq!(j["series"].as_array().unwrap().len(), 24);
+    // Leaderboard still lists the apps, each with a zeroed overview.
+    for entry in j["apps"].as_array().unwrap() {
+        assert_eq!(entry["overview"]["requests"], 0);
+    }
+}
+
+/// The three limits and the series range are honored, and empty values fall
+/// back to defaults rather than 400.
+#[tokio::test]
+async fn dashboard_honors_limits_and_range() {
+    let (s, j) = get(&format!(
+        "/api/traffic/dashboard?{RANGE}&paths_limit=1&apps_limit=1&range=7d"
+    ))
+    .await;
+    assert_eq!(s, StatusCode::OK);
+    assert_eq!(j["paths"].as_array().unwrap().len(), 1, "paths_limit=1");
+    assert_eq!(j["apps"].as_array().unwrap().len(), 1, "apps_limit=1");
+    assert_eq!(j["series"].as_array().unwrap().len(), 7, "range=7d");
+
+    let (s, _) = get(&format!(
+        "/api/traffic/dashboard?{RANGE}&paths_limit=&breakdown_limit=&apps_limit="
+    ))
+    .await;
+    assert_eq!(s, StatusCode::OK, "empty limits must default, not 400");
+}
+
+/// Malformed knobs are rejected with 400, matching the per-endpoint routes.
+#[tokio::test]
+async fn dashboard_rejects_malformed_knobs() {
+    for uri in [
+        "/api/traffic/dashboard?from=bogus",
+        "/api/traffic/dashboard?paths_limit=0",
+        "/api/traffic/dashboard?breakdown_limit=abc",
+        "/api/traffic/dashboard?apps_limit=0",
+        "/api/traffic/dashboard?range=bogus",
+    ] {
+        let (s, _) = get(uri).await;
+        assert_eq!(s, StatusCode::BAD_REQUEST, "{uri}");
+    }
 }

--- a/crates/api/src/routes/traffic/tests.rs
+++ b/crates/api/src/routes/traffic/tests.rs
@@ -1088,10 +1088,9 @@ async fn dashboard_empty_range_is_zeroed_not_404() {
     assert_eq!(j["breakdowns"]["country"].as_array().unwrap().len(), 0);
     // Series stays fixed-length and zero-filled.
     assert_eq!(j["series"].as_array().unwrap().len(), 24);
-    // Leaderboard still lists the apps, each with a zeroed overview.
-    for entry in j["apps"].as_array().unwrap() {
-        assert_eq!(entry["overview"]["requests"], 0);
-    }
+    // No app had traffic in this range, so the request-ranked leaderboard is
+    // empty (idle apps are absent, not zeroed tail entries) — still 200.
+    assert_eq!(j["apps"].as_array().unwrap().len(), 0);
 }
 
 /// The three limits and the series range are honored, and empty values fall
@@ -1127,4 +1126,16 @@ async fn dashboard_rejects_malformed_knobs() {
         let (s, _) = get(uri).await;
         assert_eq!(s, StatusCode::BAD_REQUEST, "{uri}");
     }
+}
+
+/// The per-app variant ignores `apps_limit` (it has no leaderboard), so even
+/// an invalid value must not turn into a 400 — the documented contract.
+#[tokio::test]
+async fn app_dashboard_ignores_invalid_apps_limit() {
+    let (s, j) = get(&format!(
+        "/api/app/app-a/traffic/dashboard?{RANGE}&apps_limit=0"
+    ))
+    .await;
+    assert_eq!(s, StatusCode::OK);
+    assert!(j.get("apps").is_none());
 }

--- a/crates/api/src/types.rs
+++ b/crates/api/src/types.rs
@@ -152,3 +152,48 @@ pub struct TrafficSeriesBucket {
 pub struct TrafficAttribution {
     pub attribution: Option<String>,
 }
+
+/// Everything Coolify's traffic dashboard needs in one payload, so it can
+/// replace ~15 separate round-trips with a single request. Every member is the
+/// verbatim shape of its standalone endpoint — the same serializers and
+/// server-side sketch merges — bundled, never re-summed.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrafficDashboard {
+    pub overview: TrafficOverview,
+    pub paths: Vec<TrafficPath>,
+    pub breakdowns: TrafficBreakdowns,
+    pub series: Vec<TrafficSeriesBucket>,
+    /// The active GeoIP attribution string, or `null`. Flattened out of
+    /// [`TrafficAttribution`] so the dashboard carries the bare value.
+    pub attribution: Option<String>,
+    /// Per-app leaderboard, present only on the server-wide dashboard and
+    /// omitted entirely on the per-app variant.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apps: Option<Vec<TrafficAppEntry>>,
+}
+
+/// The eleven breakdown dimensions Coolify renders, each a top-N list in the
+/// same shape as `GET /traffic/breakdown/{dim}`. A fixed struct rather than a
+/// map so the dimension set is the single source of truth and always complete.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrafficBreakdowns {
+    pub country: Vec<TrafficBreakdownEntry>,
+    pub referer: Vec<TrafficBreakdownEntry>,
+    pub browser: Vec<TrafficBreakdownEntry>,
+    pub os: Vec<TrafficBreakdownEntry>,
+    pub device: Vec<TrafficBreakdownEntry>,
+    pub protocol: Vec<TrafficBreakdownEntry>,
+    pub cache: Vec<TrafficBreakdownEntry>,
+    pub status: Vec<TrafficBreakdownEntry>,
+    pub agent: Vec<TrafficBreakdownEntry>,
+    pub ip: Vec<TrafficBreakdownEntry>,
+    pub useragent: Vec<TrafficBreakdownEntry>,
+}
+
+/// One row of the server-wide app leaderboard: an app UUID plus its overview,
+/// ranked by request count descending.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrafficAppEntry {
+    pub uuid: String,
+    pub overview: TrafficOverview,
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -659,6 +659,78 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /api/traffic/dashboard:
+    get:
+      summary: Get aggregate traffic dashboard (server-wide)
+      description: |
+        Bundle every traffic shape into one response so a dashboard can replace
+        ~15 separate requests with a single call. Each member is verbatim the
+        shape of its standalone endpoint, with the same server-side sketch
+        merges (t-digest latency, HLL uniques) — nothing is re-summed.
+
+        `overview`, `paths`, and every `breakdowns` dimension follow `from`/`to`;
+        `series` follows `range`. The server-wide variant includes `apps` (every
+        app with traffic, ranked by requests desc, capped at `apps_limit`). An
+        empty range returns 200 with zeroed/empty members, never 404.
+
+        Additive: older Coolify keeps calling the individual endpoints; new
+        Coolify calls this first and falls back to them on 404.
+      tags:
+        - Traffic Analytics
+      parameters:
+        - $ref: '#/components/parameters/FromDate'
+        - $ref: '#/components/parameters/ToDate'
+        - $ref: '#/components/parameters/Range'
+        - $ref: '#/components/parameters/PathsLimit'
+        - $ref: '#/components/parameters/BreakdownLimit'
+        - $ref: '#/components/parameters/AppsLimit'
+      responses:
+        '200':
+          description: Aggregate dashboard, including the app leaderboard
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrafficDashboard'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/TrafficNotEnabledError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/app/{uuid}/traffic/dashboard:
+    get:
+      summary: Get aggregate traffic dashboard (per app)
+      description: |
+        Per-app variant of `GET /api/traffic/dashboard`: every member filtered
+        to one app, and `apps` omitted entirely. `apps_limit` is ignored.
+      tags:
+        - Traffic Analytics
+      parameters:
+        - $ref: '#/components/parameters/AppUuid'
+        - $ref: '#/components/parameters/FromDate'
+        - $ref: '#/components/parameters/ToDate'
+        - $ref: '#/components/parameters/Range'
+        - $ref: '#/components/parameters/PathsLimit'
+        - $ref: '#/components/parameters/BreakdownLimit'
+      responses:
+        '200':
+          description: Aggregate dashboard for one app (no leaderboard)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrafficDashboard'
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/TrafficNotEnabledError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/stats:
     get:
       summary: Get database statistics
@@ -750,6 +822,44 @@ components:
         enum: [24h, 7d, 30d]
         default: 24h
       example: 7d
+
+    PathsLimit:
+      name: paths_limit
+      in: query
+      description: Top-N cap for the dashboard's `paths`. Defaults to 50, capped at 1000.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 50
+      example: 25
+
+    BreakdownLimit:
+      name: breakdown_limit
+      in: query
+      description: Top-N cap per dashboard breakdown dimension. Defaults to 50, capped at 1000.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 50
+      example: 25
+
+    AppsLimit:
+      name: apps_limit
+      in: query
+      description: |
+        Cap for the server-wide dashboard's `apps` leaderboard. Defaults to
+        200, capped at 1000. Ignored by the per-app variant.
+      required: false
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 1000
+        default: 200
+      example: 100
 
   schemas:
     CurrentCPUUsage:
@@ -1148,6 +1258,99 @@ components:
             when GeoIP is disabled, not yet resolved, or the active source
             is an unrecognized GEOIP_DB_URL override.
           example: "This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com"
+
+    TrafficBreakdowns:
+      type: object
+      description: |
+        The eleven breakdown dimensions Coolify renders, each a top-N list in
+        the same shape as GET /traffic/breakdown/{dimension}.
+      properties:
+        country:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        referer:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        browser:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        os:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        device:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        protocol:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        cache:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        status:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        agent:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        ip:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+        useragent:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficBreakdownEntry'
+
+    TrafficAppEntry:
+      type: object
+      description: One row of the server-wide app leaderboard.
+      properties:
+        uuid:
+          type: string
+          example: jc4wsgs
+        overview:
+          $ref: '#/components/schemas/TrafficOverview'
+
+    TrafficDashboard:
+      type: object
+      description: |
+        Every traffic shape bundled into one response. Each member is verbatim
+        the shape of its standalone endpoint. `apps` is present only on the
+        server-wide variant.
+      properties:
+        overview:
+          $ref: '#/components/schemas/TrafficOverview'
+        paths:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficPath'
+        breakdowns:
+          $ref: '#/components/schemas/TrafficBreakdowns'
+        series:
+          type: array
+          items:
+            $ref: '#/components/schemas/TrafficSeriesBucket'
+        attribution:
+          type: string
+          nullable: true
+          description: The active GeoIP source's attribution string, or null.
+          example: "This product includes GeoLite2 data created by MaxMind, available from https://www.maxmind.com"
+        apps:
+          type: array
+          description: |
+            Per-app leaderboard, ranked by requests desc. Present only on the
+            server-wide dashboard; omitted on the per-app variant.
+          items:
+            $ref: '#/components/schemas/TrafficAppEntry'
 
     DatabaseStats:
       type: object


### PR DESCRIPTION
## What

Adds an aggregate traffic-dashboard endpoint that collapses Coolify's ~15 separate per-page traffic requests into one call.

- `GET /api/traffic/dashboard` — server-wide, includes the `apps` leaderboard
- `GET /api/app/:uuid/traffic/dashboard` — per-app, omits `apps`

## Response

One JSON object bundling the existing shapes **verbatim**:

```json
{
  "overview":    { /* identical to GET /traffic/overview */ },
  "paths":       [ /* identical to GET /traffic/paths */ ],
  "breakdowns":  { "country": [], "referer": [], "browser": [], "os": [],
                   "device": [], "protocol": [], "cache": [], "status": [],
                   "agent": [], "ip": [], "useragent": [] },
  "series":      [ /* identical to GET /traffic/series */ ],
  "attribution": "GeoIP data by MaxMind" | null,
  "apps":        [ { "uuid": "…", "overview": { /* per-app overview */ } } ]
}
```

## How

- A `Target` enum (`Server` / `App`) unifies the two store method families so `build_dashboard` runs a single code path.
- Reuses the exact merge helpers (`summarize_stats`, `top_paths`, `top_breakdown`, `aggregate_series`) — t-digest latency and HLL uniques merged server-side, **never** summed.
- Whole payload built in one `spawn_blocking` under one query permit.
- Query knobs: `from`/`to` (ISO-8601 Zulu) drive overview/paths/breakdowns; `range` (24h/7d/30d) drives the series independently; `paths_limit`/`breakdown_limit` (default 50, max 1000), `apps_limit` (default 200, max 1000). Empty values fall back to defaults; malformed → 400.
- Breakdown dimensions match Coolify's list exactly (the struct fields *are* the list).
- Leaderboard ranked by requests desc (tie-break uuid asc), capped at `apps_limit`.

## Constraints met

- Same bearer-token auth (existing middleware — automatic).
- Empty range → **200** with zeroed/empty members, never 404. Only 404 is analytics-disabled.
- Additive: older Coolify keeps calling the individual endpoints; new Coolify calls this first and falls back on 404, exactly like it already does for `/series`.
- `API.md` and `openapi.yaml` updated; tests mirror the existing per-endpoint traffic tests.

## Testing

```bash
cargo test --workspace --features traffic   # all pass, 5 new dashboard tests
cargo clippy --workspace --features traffic # clean
cargo build                                 # default (no-traffic) build compiles
```

New tests: bundles-every-member, per-app filters/omits-leaderboard, empty-range-is-zeroed, honors-limits-and-range, rejects-malformed-knobs; plus both routes added to the disabled-404 sweep.

## Notes

- No version bump — additive change, not a release. Happy to bump the 4 version locations if you'd prefer to cut one.
- No related open issues/discussions on the repo.